### PR TITLE
Updated the parameter in the README to display proper parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can also provide `service`, which defaults to `"api2.transloadit.com"`, and 
 
 Registers the local file with the client. The next call to `createAssembly` will upload that file.
 
-#### TransloaditClient.addStream(stream)
+#### TransloaditClient.addStream(name, stream)
 
 Registers the provided stream with the client. The next call to `createAssembly` will upload that stream.
 


### PR DESCRIPTION
I was trying to get the addStream function to work, but when I looked in [TransloaditClient.js](https://github.com/transloadit/node-sdk/blob/master/lib/TransloaditClient.js), I realized that I needed to pass a name to it as well.
