### PR TITLE
Added SSL option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 credentials.js
 sample.js
+.idea

--- a/lib/TransloaditClient.js
+++ b/lib/TransloaditClient.js
@@ -19,7 +19,7 @@
       this._authSecret = opts.authSecret || null;
       this._service = opts.service || "api2.transloadit.com";
       this._region = opts.region || "us-east-1";
-      this._protocol = "http://";
+      this._protocol = opts.useSsl ? "https://" : "http://";
       this._streams = {};
       this._lastUsedAssemblyUrl = "";
     }

--- a/src/TransloaditClient.coffee
+++ b/src/TransloaditClient.coffee
@@ -12,7 +12,7 @@ class TransloaditClient
     @_authSecret = opts.authSecret || null
     @_service    = opts.service || "api2.transloadit.com"
     @_region     = opts.region || "us-east-1"
-    @_protocol   = "http://"
+    @_protocol   = if opts.useSsl then "https://" else "http://"
     @_streams    = {}
 
     @_lastUsedAssemblyUrl = ""

--- a/test/test-transloadit-client.coffee
+++ b/test/test-transloadit-client.coffee
@@ -20,13 +20,15 @@ describe "TransloaditClient", ->
         authKey    : "foo_key"
         authSecret : "foo_secret"
         service    : "foo_service"
-        region     : "foo_region"
+        region     : "foo_region",
+        useSsl     : true
 
       client = new TransloaditClient opts
       expect(client._authKey).to.equal "foo_key"
       expect(client._authSecret).to.equal "foo_secret"
       expect(client._service).to.equal "foo_service"
       expect(client._region).to.equal "foo_region"
+      expect(client._protocol).to.equal "https://"
 
   describe "addStream", ->
     it "should properly add a stream", ->


### PR DESCRIPTION
Via passing the `useSsl` parameter it's possible to use SSL encryption for all transloadit API requests

Also adjusted the tests