### PR TITLE
[WIP] General SDK enhancements

### DIFF
--- a/lib/TransloaditClient.js
+++ b/lib/TransloaditClient.js
@@ -76,23 +76,37 @@
     };
 
     TransloaditClient.prototype.deleteAssembly = function(assemblyId, cb) {
-      var opts;
+      var finallyDelete, operation, opts;
       opts = {
         url: this._serviceUrl() + ("/assemblies/" + assemblyId),
         timeout: 16000
       };
-      return this._remoteJson(opts, (function(_this) {
-        return function(err, result) {
-          if (err != null) {
-            return cb(err);
-          }
+      finallyDelete = (function(_this) {
+        return function(assemblyUrl) {
           opts = {
-            url: result.assembly_url,
+            url: assemblyUrl,
             timeout: 5000,
             method: "del",
             params: {}
           };
           return _this._remoteJson(opts, cb);
+        };
+      })(this);
+      operation = retry.operation();
+      return operation.attempt((function(_this) {
+        return function(attempt) {
+          return _this._remoteJson(opts, function(err, result) {
+            if (err != null) {
+              return cb(err);
+            }
+            if (result.assembly_url == null) {
+              if (operation.retry(new Error("failed to retrieve assembly_url"))) {
+                return;
+              }
+              return cb(operation.mainError());
+            }
+            return finallyDelete(result.assembly_url);
+          });
         };
       })(this));
     };

--- a/lib/TransloaditClient.js
+++ b/lib/TransloaditClient.js
@@ -86,16 +86,20 @@
         url: this._serviceUrl() + ("/assemblies/" + assemblyId),
         timeout: 16000
       };
-      return this._remoteJson(opts, function(err, result) {
-        if (err) {
-          return cb(err);
-        }
-        opts = {
-          url: result.assembly_url,
-          timeout: 5000
+      return this._remoteJson(opts, (function(_this) {
+        return function(err, result) {
+          if (err != null) {
+            return cb(err);
+          }
+          opts = {
+            url: result.assembly_url,
+            timeout: 5000,
+            method: "del",
+            params: {}
+          };
+          return _this._remoteJson(opts, cb);
         };
-        return request.del(opts, cb);
-      });
+      })(this));
     };
 
     TransloaditClient.prototype.replayAssembly = function(opts, cb) {
@@ -215,10 +219,7 @@
       var requestOpts;
       requestOpts = {
         url: this._serviceUrl() + ("/templates/" + templateId),
-        method: "put",
-        headers: {
-          "X-Method-Override": "DELETE"
-        },
+        method: "del",
         params: {}
       };
       return this._remoteJson(requestOpts, cb);
@@ -465,6 +466,9 @@
           msg = "Unable to parse JSON from '" + requestOpts.uri + "'. ";
           msg += "Code: " + res.statusCode + ". Body: " + abbr + ". ";
           return cb(new Error(msg));
+        }
+        if (result.error != null) {
+          return cb(new Error("API returned error. Code: " + result.error + ". Message: " + result.message));
         }
         return cb(null, result);
       });

--- a/lib/TransloaditClient.js
+++ b/lib/TransloaditClient.js
@@ -51,31 +51,26 @@
     };
 
     TransloaditClient.prototype.createAssembly = function(opts, cb) {
-      return this._getBoredInstance(null, true, (function(_this) {
-        return function(err, url) {
-          var requestOpts;
-          if (err || (url == null)) {
+      var requestOpts;
+      this._lastUsedAssemblyUrl = (this._serviceUrl()) + "/assemblies";
+      requestOpts = {
+        url: this._lastUsedAssemblyUrl,
+        method: "post",
+        timeout: 24 * 60 * 60 * 1000,
+        params: opts.params || {},
+        fields: opts.fields || {}
+      };
+      return this._remoteJson(requestOpts, (function(_this) {
+        return function(err, result) {
+          _this._streams = {};
+          if (err) {
             return cb(err);
           }
-          _this._lastUsedAssemblyUrl = _this._protocol + "api2-" + url + "/assemblies";
-          requestOpts = {
-            url: _this._lastUsedAssemblyUrl,
-            method: "post",
-            timeout: 24 * 60 * 60 * 1000,
-            params: opts.params || {},
-            fields: opts.fields || {}
-          };
-          return _this._remoteJson(requestOpts, function(err, result) {
-            _this._streams = {};
-            if (err) {
-              return cb(err);
-            }
-            if (result && result.ok) {
-              return cb(null, result);
-            }
-            err = new Error(result.error || "NOT OK");
-            return cb(err);
-          });
+          if (result && result.ok) {
+            return cb(null, result);
+          }
+          err = new Error(result.error || "NOT OK");
+          return cb(err);
         };
       })(this));
     };
@@ -295,89 +290,6 @@
       jsonParams = encodeURIComponent(jsonParams);
       url += "&params=" + jsonParams;
       return url;
-    };
-
-    TransloaditClient.prototype._getBoredInstance = function(url, customBoredLogic, cb) {
-      var opts;
-      if (url == null) {
-        url = this._serviceUrl() + "/instances/bored";
-      }
-      opts = {
-        url: url
-      };
-      return this._remoteJson(opts, (function(_this) {
-        return function(err, instance) {
-          if (!err) {
-            if (instance.error) {
-              return cb(instance.error);
-            }
-            return cb(null, instance.api2_host);
-          }
-          if (customBoredLogic) {
-            _this._findBoredInstanceUrl(function(err, theUrl) {
-              if (err) {
-                err = {
-                  error: "BORED_INSTANCE_ERROR",
-                  message: "Could not find a bored instance. " + err.message
-                };
-                return cb(err);
-              }
-              url = _this._protocol + "api2-" + theUrl + "/instances/bored";
-              return _this._getBoredInstance(url, false, cb);
-            });
-            return;
-          }
-          err = {
-            error: "CONNECTION_ERROR",
-            message: "There was a problem connecting to the upload server",
-            reason: err.message,
-            url: url
-          };
-          return cb(err);
-        };
-      })(this));
-    };
-
-    TransloaditClient.prototype._findBoredInstanceUrl = function(cb) {
-      var opts, url;
-      url = "http://infra-" + this._region + ".transloadit.com.s3.amazonaws.com/";
-      url += "cached_instances.json";
-      opts = {
-        url: url,
-        timeout: 3000
-      };
-      return this._remoteJson(opts, (function(_this) {
-        return function(err, result) {
-          var instances;
-          if (err) {
-            err.message = "Could not query S3 for cached uploaders: " + err.message;
-            return cb(err);
-          }
-          instances = _.shuffle(result.uploaders);
-          return _this._findResponsiveInstance(instances, 0, cb);
-        };
-      })(this));
-    };
-
-    TransloaditClient.prototype._findResponsiveInstance = function(instances, index, cb) {
-      var err, opts, url;
-      if (!instances[index]) {
-        err = new Error("No responsive uploaders");
-        return cb(err);
-      }
-      url = instances[index];
-      opts = {
-        url: this._protocol + url,
-        timeout: 3000
-      };
-      return this._remoteJson(opts, (function(_this) {
-        return function(err, result) {
-          if (err) {
-            return _this._findResponsiveInstance(instances, index + 1, cb);
-          }
-          return cb(null, url);
-        };
-      })(this));
     };
 
     TransloaditClient.prototype._prepareParams = function(params) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coffee-script": "1.10.0",
     "coffeelint": "1.15.7",
     "gently": "0.10.0",
-    "localtunnel": "^1.8.1",
+    "localtunnel": "1.8.1",
     "mocha": "3.0.0-2",
     "should": "10.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "npm-run-all lint transpile",
-    "lint": "coffeelint --file ./coffeelint.json src",
+    "lint": "coffeelint --file ./coffeelint.json src test",
     "mocha": "node_modules/.bin/mocha --compilers coffee:coffee-script --require 'coffee-script/register' --reporter spec test/",
     "next:update": "next-update --keep true --tldr",
     "release:major": "env SEMANTIC=major npm run release",

--- a/src/TransloaditClient.coffee
+++ b/src/TransloaditClient.coffee
@@ -14,7 +14,7 @@ class TransloaditClient
     if !opts.authKey?
       throw new Error "Please provide an authKey"
 
-    if !opts.authKey?
+    if !opts.authSecret?
       throw new Error "Please provide an authSecret"
 
     @_authKey    = opts.authKey

--- a/src/TransloaditClient.coffee
+++ b/src/TransloaditClient.coffee
@@ -65,17 +65,11 @@ class TransloaditClient
         err = new Error(result.error || "NOT OK")
         cb err
 
-  # Looks up the assembly_url for the given assembly_id, then deletes sends a
-  # DELETE to the assembly_url.
-  # TODO this adds an unnecessary extra request, Assembly Status responses
-  # already report the assembly_url. However other endpoints use the
-  # assembly_id. Ideas for addressing he inefficientcy without compromising
-  # consistency:
-  # - Accept either assembly_ids or assembly_urls in all methods
-  #   - Disadvantage: it's not clear which is more efficient from the API layer,
-  #     may result in using assembly_urls for everything, which would be worse
-  #     than right now.
-  # - Offer a seperate optimized version of deleteAssembly
+  # Check if the specified assembly exists, canceling it if it does.
+  # TODO this adds an unnecessary extra request, the endpoint should properly
+  # handle when the specified assembly doesn't exist.
+  # TODO the DELETE request is issued directly through request.del, bypassing
+  # _calcSignature
   deleteAssembly: (assemblyId, cb) ->
     opts =
       url     : @_serviceUrl() + "/assemblies/#{assemblyId}"
@@ -382,6 +376,9 @@ class TransloaditClient
   # method default "get"
   # params optional
   # fields optional
+  # TODO maybe "del" requests should be handled by something other than
+  # @_appendForm, since neither callsite issuing a DELETE request follows that
+  # path of execution.
   __remoteJson: (opts, cb) ->
     timeout = opts.timeout || 5000
     url     = opts.url || null

--- a/src/TransloaditClient.coffee
+++ b/src/TransloaditClient.coffee
@@ -37,7 +37,6 @@ class TransloaditClient
   getLastUsedAssemblyUrl: ->
     return @_lastUsedAssemblyUrl
 
-  # On success, calls cb with an Assembly Status Response
   createAssembly: (opts, cb) ->
     @_lastUsedAssemblyUrl = "#{@_serviceUrl()}/assemblies"
 
@@ -61,9 +60,6 @@ class TransloaditClient
       err = new Error(result.error || "NOT OK")
       cb err
 
-  # Check if the specified assembly exists, canceling it if it does.
-  # TODO this adds an unnecessary extra request, the endpoint should properly
-  # handle when the specified assembly doesn't exist.
   deleteAssembly: (assemblyId, cb) ->
     opts =
       url     : @_serviceUrl() + "/assemblies/#{assemblyId}"
@@ -76,8 +72,6 @@ class TransloaditClient
         method  : "del"
         params  : {}
 
-      # TODO this breaks compatability, the cb used to take the request
-      # library's three parameters: error, response, body.
       @_remoteJson opts, cb
 
     operation = retry.operation()
@@ -119,8 +113,6 @@ class TransloaditClient
 
     @_remoteJson requestOpts, cb
   
-  # This method is fairly low level, as it doesn't manage pagination. Maybe it
-  # could be deprecated in favor of a generator method.
   listAssemblyNotifications: (params, cb) ->
     requestOpts =
       url     : @_serviceUrl() + "/assembly_notifications"
@@ -129,7 +121,6 @@ class TransloaditClient
 
     @_remoteJson requestOpts, cb
   
-  # Doesn't handle pagination, see listAssemblyNotifications
   listAssemblies: (params, cb) ->
     requestOpts =
       url     : @_serviceUrl() + "/assemblies"
@@ -218,9 +209,6 @@ class TransloaditClient
 
     return {signature: signature, params: jsonParams}
 
-  # Does this really need to be its own method? Looks like it doesn't need to be
-  # anymore. See:
-  # https://github.com/transloadit/node-sdk/commit/d23ecaff92a6bb33cb18810e433fcbcd7d31c562
   _calcSignature: (toSign) ->
     return crypto
       .createHmac("sha1", @_authSecret)
@@ -308,12 +296,6 @@ class TransloaditClient
   # Responsible for making API calls. Automatically sends streams with any POST,
   # PUT or DELETE requests. Automatically adds signature parameters to all
   # requests. Also automatically parses the JSON response.
-  # opts fields:
-  # timeout default 5000
-  # url required
-  # method default "get"
-  # params optional
-  # fields optional
   __remoteJson: (opts, cb) ->
     timeout = opts.timeout || 5000
     url     = opts.url || null

--- a/src/TransloaditClient.coffee
+++ b/src/TransloaditClient.coffee
@@ -82,7 +82,7 @@ class TransloaditClient
 
     operation = retry.operation()
     operation.attempt (attempt) =>
-      @_remoteJson opts, (err, result) =>
+      @_remoteJson opts, (err, result) ->
         if err?
           return cb err
         

--- a/test/gently-preamble.coffee
+++ b/test/gently-preamble.coffee
@@ -1,0 +1,2 @@
+global.Gently = require "gently"
+module.exports = global.GENTLY = new Gently()

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -1,3 +1,4 @@
+require "./gently-preamble"
 expect            = require("chai").expect
 TransloaditClient = require "../src/TransloaditClient"
 request           = require "request"

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -22,7 +22,7 @@ startServer = (handler, cb) ->
 
   # Find a port to use
   port = 8000
-  server.on "error", (err) =>
+  server.on "error", (err) ->
     if err.code == "EADDRINUSE"
       if ++port >= 65535
         server.close()
@@ -35,14 +35,14 @@ startServer = (handler, cb) ->
 
   # Once a port has been found and the server is ready, setup the
   # localtunnel
-  server.on "listening", =>
-    localtunnel port, (err, tunnel) =>
+  server.on "listening", ->
+    localtunnel port, (err, tunnel) ->
       if err?
         server.close()
         return cb err
       cb null,
         url: tunnel.url
-        close: =>
+        close: ->
           tunnel.close()
           server.close()
 
@@ -67,7 +67,7 @@ describe "API integration", ->
     it "should create a retrievable assembly on the server", (done) ->
       client = new TransloaditClient { authKey, authSecret }
 
-      client.createAssembly genericParams, (err, result) =>
+      client.createAssembly genericParams, (err, result) ->
         expect(err).to.not.exist
         expect(result).to.not.have.property "error"
         expect(result).to.have.property "ok"
@@ -75,7 +75,7 @@ describe "API integration", ->
         
         id = result.assembly_id
 
-        client.getAssembly id, (err, result) =>
+        client.getAssembly id, (err, result) ->
           expect(err).to.not.exist
           expect(result).to.not.have.property "error"
           expect(result).to.have.property "ok"
@@ -105,8 +105,8 @@ describe "API integration", ->
       readyToServe = false
       callback = -> undefined # No-op function
 
-      handler = (req, res) =>
-        handleRequest = =>
+      handler = (req, res) ->
+        handleRequest = ->
           expect(url.parse(req.url).pathname).to.equal "/"
 
           res.setHeader "Content-type", "image/jpeg"
@@ -119,7 +119,7 @@ describe "API integration", ->
         else
           callback = handleRequest
 
-      startServer handler, (err, server) =>
+      startServer handler, (err, server) ->
         expect(err).to.not.exist
         # TODO the server won't close if the test fails
 
@@ -137,13 +137,13 @@ describe "API integration", ->
                 height: 130
 
         # Finally send the createAssembly request
-        client.createAssembly params, (err, result) =>
+        client.createAssembly params, (err, result) ->
           expect(err).to.not.exist
 
           id = result.assembly_id
           
           # Now delete it
-          client.deleteAssembly id, (err, result) =>
+          client.deleteAssembly id, (err, result) ->
             # Allow the upload to finish
             readyToServe = true
             callback()
@@ -154,7 +154,7 @@ describe "API integration", ->
             # Successful cancel requests get ASSEMBLY_CANCELED even when it
             # completed, so we now request the assembly status to check the
             # *actual* status.
-            client.getAssembly id, (err, result) =>
+            client.getAssembly id, (err, result) ->
               expect(err).to.not.exist
               expect(result.ok).to.equal "ASSEMBLY_CANCELED"
               server.close()
@@ -164,14 +164,14 @@ describe "API integration", ->
     it "should replay an assembly after it has completed", (done) ->
       client = new TransloaditClient { authKey, authSecret }
       
-      client.createAssembly genericParams, (err, result) =>
+      client.createAssembly genericParams, (err, result) ->
         expect(err).to.not.exist
 
         originalId = result.assembly_id
         
         # ensure that the assembly has completed
-        ensureCompletion = (cb) =>
-          client.getAssembly originalId, (err, result) =>
+        ensureCompletion = (cb) ->
+          client.getAssembly originalId, (err, result) ->
             expect(err).to.not.exist
 
             if result.ok == "ASSEMBLY_UPLOADING" || result.ok == "ASSEMBLY_EXECUTING"
@@ -179,8 +179,8 @@ describe "API integration", ->
             else
               cb()
 
-        ensureCompletion =>
-          client.replayAssembly { assembly_id: originalId }, (err, result) =>
+        ensureCompletion ->
+          client.replayAssembly { assembly_id: originalId }, (err, result) ->
             expect(err).to.not.exist
             expect(result.ok).to.equal "ASSEMBLY_REPLAYING"
             done()
@@ -189,7 +189,7 @@ describe "API integration", ->
     it "should retrieve a list of assemblies", (done) ->
       client = new TransloaditClient { authKey, authSecret }
 
-      client.listAssemblies {}, (err, result) =>
+      client.listAssemblies {}, (err, result) ->
         expect(err).to.not.exist
         expect(result).to.have.property "count"
         expect(result).to.have.property("items").that.is.instanceof Array
@@ -197,45 +197,45 @@ describe "API integration", ->
 
   describe "assembly notification", ->
     # helper function
-    streamToString = (stream, cb) =>
+    streamToString = (stream, cb) ->
       chunks = []
-      stream.on "data", (chunk) => chunks.push chunk
-      stream.on "error", (err) => cb err
-      stream.on "end", => cb null, chunks.join ""
+      stream.on "data", (chunk) -> chunks.push chunk
+      stream.on "error", (err) -> cb err
+      stream.on "end", -> cb null, chunks.join ""
 
-    testCase = (desc, endBehavior) =>
+    testCase = (desc, endBehavior) ->
       it desc, (done) ->
         client = new TransloaditClient { authKey, authSecret }
 
         # listens for notifications
-        handler = (req, res) =>
+        handler = (req, res) ->
           expect(url.parse(req.url).pathname).to.equal "/"
 
           expect(req.method).to.equal "POST"
-          streamToString req, (err, body) =>
+          streamToString req, (err, body) ->
             result = JSON.parse querystring.parse(body).transloadit
             expect(result).to.have.property("ok").that.equals "ASSEMBLY_COMPLETED"
             res.writeHead 200
             res.end()
             endBehavior client, result.assembly_id, done
 
-        startServer handler, (err, server) =>
+        startServer handler, (err, server) ->
           expect(err).to.not.exist
           
           params =
             params: _.extend genericParams.params,
               notify_url: server.url
 
-          client.createAssembly params, (err, result) =>
+          client.createAssembly params, (err, result) ->
             expect(err).to.not.exist
             
-    testCase "should send a notification upon assembly completion", (client, id, done) =>
+    testCase "should send a notification upon assembly completion", (client, id, done) ->
       done()
 
     notificationsRecvd = 0
-    testCase "should replay the notification when requested", (client, id, done) =>
+    testCase "should replay the notification when requested", (client, id, done) ->
       if notificationsRecvd++ == 0
-        client.replayAssemblyNotification { assembly_id: id }, (err) =>
+        client.replayAssemblyNotification { assembly_id: id }, (err) ->
           expect(err).to.not.exist
       else
         done()
@@ -246,7 +246,7 @@ describe "API integration", ->
     client = new TransloaditClient { authKey, authSecret }
 
     it "should allow creating a template", (done) ->
-      client.createTemplate { name: templName, template: genericParams.params }, (err, result) =>
+      client.createTemplate { name: templName, template: genericParams.params }, (err, result) ->
         expect(err).to.not.exist
         templId = result.template_id
         done()
@@ -255,7 +255,7 @@ describe "API integration", ->
     it "should be able to fetch a template's definition", (done) ->
       expect(templId).to.exist
 
-      client.getTemplate templId, (err, result) =>
+      client.getTemplate templId, (err, result) ->
         expect(err).to.not.exist
         expect(result.template_name).to.equal templName
         expect(result.template_content).to.deep.equal genericParams.params
@@ -264,10 +264,10 @@ describe "API integration", ->
     it "should delete the template successfully", (done) ->
       expect(templId).to.exist
 
-      client.deleteTemplate templId, (err, result) =>
+      client.deleteTemplate templId, (err, result) ->
         expect(err).to.not.exist
         expect(result.ok).to.equal "TEMPLATE_DELETED"
-        client.getTemplate templId, (err, result) =>
+        client.getTemplate templId, (err, result) ->
           expect(result).to.not.exist
           expect(err).to.exist
           expect(err.message).to.match /TEMPLATE_NOT_FOUND/

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -12,10 +12,10 @@ _                 = require "underscore"
 authKey    = process.env.TRANSLOADIT_KEY
 authSecret = process.env.TRANSLOADIT_SECRET
 unless authKey? && authSecret?
-  msg  = "specify envrionment variables TRANSLOADIT_KEY and TRANSLOADIT_SECRET"
+  msg  = "specify environment variables TRANSLOADIT_KEY and TRANSLOADIT_SECRET"
   msg += " to enable integration tests."
   console.warn msg
-  return # Terminates module execution without existing the test process
+  return # Terminates module execution without exiting the test process
 
 startServer = (handler, cb) ->
   server = http.createServer handler

--- a/test/integration.coffee
+++ b/test/integration.coffee
@@ -185,3 +185,13 @@ describe "API integration", ->
             expect(err).to.not.exist
             expect(result.ok).to.equal "ASSEMBLY_REPLAYING"
             done()
+
+  describe "assembly list retrieval", ->
+    it "should retrieve a list of assemblies", (done) ->
+      client = new TransloaditClient { authKey, authSecret }
+
+      client.listAssemblies {}, (err, result) =>
+        expect(err).to.not.exist
+        expect(result).to.have.property "count"
+        expect(result).to.have.property("items").that.is.instanceof Array
+        done()

--- a/test/test-transloadit-client.coffee
+++ b/test/test-transloadit-client.coffee
@@ -1,6 +1,4 @@
-global.Gently = require "gently"
-gently = global.GENTLY = new Gently()
-
+gently            = require "./gently-preamble"
 should            = require("chai").should()
 expect            = require("chai").expect
 TransloaditClient = require "../src/TransloaditClient"

--- a/test/test-transloadit-client.coffee
+++ b/test/test-transloadit-client.coffee
@@ -444,6 +444,7 @@ describe "TransloaditClient", ->
 
       opts =
         authKey: "foo"
+        authSecret: "foo_secret"
       client = new TransloaditClient opts
 
       r = JSON.parse client._prepareParams()

--- a/test/test-transloadit-client.coffee
+++ b/test/test-transloadit-client.coffee
@@ -273,9 +273,7 @@ describe "TransloaditClient", ->
 
       REQUEST_OPTS =
         url    : url
-        method : "put"
-        headers :
-          "X-Method-Override": "DELETE"
+        method : "del"
         params : {}
 
       CB = {}

--- a/test/test-transloadit-client.coffee
+++ b/test/test-transloadit-client.coffee
@@ -62,7 +62,7 @@ describe "TransloaditClient", ->
       client.addFile NAME, PATH
 
   describe "createAssembly", ->
-    it "should request a bored instance and then send the request", ->
+    it "should send a valid request", ->
       client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
       client._streams = "foo"
 
@@ -71,7 +71,7 @@ describe "TransloaditClient", ->
         fields  : "foo_fields"
 
       REQUEST_OPTS =
-        url     : "https://api2-tim.transloadit.com/assemblies"
+        url     : "https://api2.transloadit.com/assemblies"
         method  : "post"
         timeout : 24 * 60 * 60 * 1000
         params  : "foo_params"
@@ -80,7 +80,6 @@ describe "TransloaditClient", ->
       ERR    = {}
       RESULT =
         ok: "foo_ok"
-      URL    = "tim.transloadit.com"
 
       errCalls = 0
       calls    = 0
@@ -93,30 +92,20 @@ describe "TransloaditClient", ->
 
         calls++
 
-      gently.expect client, "_getBoredInstance", (url, customBoredLogic, cb) ->
-        expect(url).to.equal null
-        expect(customBoredLogic).to.equal true
+      gently.expect client, "_remoteJson", (opts, cb2) ->
+        expect(opts).to.eql REQUEST_OPTS
 
-        cb ERR
+        cb2 ERR
+        expect(client._streams).to.eql {}
 
-        gently.expect client, "_remoteJson", (opts, cb2) ->
-          expect(opts).to.eql REQUEST_OPTS
-
-          cb2 ERR
-          expect(client._streams).to.eql {}
-
-          cb2 null, RESULT
-
-
-        cb null, URL
-
+        cb2 null, RESULT
 
       client.createAssembly OPTS, CB
-      expect(errCalls).to.equal 2
-      expect(calls).to.equal 3
+      expect(errCalls).to.equal 1
+      expect(calls).to.equal 2
 
       usedUrl = client.getLastUsedAssemblyUrl()
-      expect(usedUrl).to.equal "https://api2-tim.transloadit.com/assemblies"
+      expect(usedUrl).to.equal "https://api2.transloadit.com/assemblies"
 
   describe "deleteAssembly", ->
     it "should find the assembly url, and then call DELETE on it", ->
@@ -448,157 +437,6 @@ describe "TransloaditClient", ->
 
       expected = "#{URL}?signature=#{SIGNATURE.signature}&params=#{ENCODED_PARAMS}"
       expect(url).to.equal expected
-
-  describe "_getBoredInstance", ->
-    it "should figure out a bored instance", ->
-      client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
-
-      URL          = "foo_url"
-      CUSTOM_LOGIC = true
-      INSTANCE     =
-        api2_host: "some_host"
-
-      calls = 0
-      CB = (err, host) ->
-        expect(host).to.equal INSTANCE.api2_host
-        calls++
-
-      gently.expect client, "_remoteJson", (opts, cb) ->
-        expect(opts.url).to.equal URL
-
-        cb null, INSTANCE
-
-      client._getBoredInstance URL, CUSTOM_LOGIC, CB
-      expect(calls).to.equal 1
-
-    it "should resolve to the custom bored logic if that fails", ->
-      client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
-      URL          = "foo_url"
-      CUSTOM_LOGIC = true
-      INSTANCE     =
-        api2_host: "some_host"
-
-      ERR = {}
-      ERR2 = {}
-      NEW_URL = "foo2_url"
-
-      calls    = 0
-      errCalls = 0
-      CB = (err, host) ->
-        if err
-          expect(err.error).to.equal "BORED_INSTANCE_ERROR"
-          errCalls++
-
-        calls++
-
-      gently.expect client, "_remoteJson", (opts, cb) ->
-        expect(opts.url).to.equal URL
-
-        gently.expect client, "_findBoredInstanceUrl", (cb2) ->
-          cb2 ERR2
-
-          gently.expect client, "_getBoredInstance", (url, customLogic, cb3) ->
-            expect(url).to.equal "https://api2-foo2_url/instances/bored"
-            expect(customLogic).to.equal false
-            expect(cb3).to.equal CB
-
-          cb2 null, NEW_URL
-
-        cb ERR
-
-      client._getBoredInstance URL, CUSTOM_LOGIC, CB
-      expect(calls).to.equal 1
-      expect(errCalls).to.equal 1
-
-  describe "_findBoredInstanceUrl", ->
-    it "should find all uploaders from the cached S3 instances", ->
-      client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
-
-      errCalls  = 0
-      calls     = 0
-      ERR       = new Error "foo"
-      INSTANCES = [
-        "foo0.transloadit.com"
-        "foo1.transloadit.com"
-      ]
-      RESULT =
-        uploaders: ["foo", "foo2"]
-
-      INSTANCES = []
-
-      CB = (err) ->
-        if err
-          errCalls++
-          msg = "Could not query S3 for cached uploaders: foo"
-          expect(err.message).to.equal msg
-
-        calls++
-
-      gently.expect client, "_remoteJson", (opts, cb) ->
-        expect(opts.url).to.equal "http://infra-us-east-1.transloadit.com.s3.amazonaws.com/cached_instances.json"
-        expect(opts.timeout).to.equal 3000
-
-        cb ERR
-
-        gently.expect GENTLY.hijacked.underscore, "shuffle", (instances) ->
-          expect(instances).to.eql RESULT.uploaders
-          return INSTANCES
-
-        gently.expect client, "_findResponsiveInstance", (instances, index, cb) ->
-          expect(instances).to.eql INSTANCES
-          expect(index).to.equal 0
-          expect(cb).to.equal CB
-
-        cb null, RESULT
-
-      client._findBoredInstanceUrl CB
-      expect(errCalls).to.equal 1
-      expect(calls).to.equal 1
-
-  describe "_findResponsiveInstance", ->
-    it "should error out if it cannot find any more instances", ->
-      client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
-
-      calls = 0
-      CB = (err) ->
-        expect(err.message).to.equal "No responsive uploaders"
-        calls++
-
-      client._findResponsiveInstance [], 1, CB
-      expect(calls).to.equal 1
-
-    it "should figure out a responsive instance from the ones given to it", ->
-      client = new TransloaditClient authKey: "foo_key", authSecret: "foo_secret"
-
-      calls     = 0
-      ERR       = {}
-      INDEX     = 1
-      INSTANCES = [
-        "foo0.transloadit.com"
-        "foo1.transloadit.com"
-      ]
-
-      CB = (err, url) ->
-        if !err
-          expect(url).to.equal "foo1.transloadit.com"
-
-        calls++
-
-      gently.expect client, "_remoteJson", (opts, cb) ->
-        expect(opts.url).to.equal "https://foo1.transloadit.com"
-        expect(opts.timeout).to.equal 3000
-
-        gently.expect client, "_findResponsiveInstance", (instances, index, cb) ->
-          expect(instances).to.eql INSTANCES
-          expect(index).to.equal INDEX + 1
-          expect(cb).to.equal CB
-
-        cb ERR
-
-        cb()
-
-      client._findResponsiveInstance INSTANCES, INDEX, CB
-      expect(calls).to.equal 1
 
   describe "_prepareParams", ->
     it "should add the auth key, secret and expires parameters", ->


### PR DESCRIPTION
This pull request represents the changes I've seen fit to make to the SDK so far. Possible concerns:

- I have changed the behavior in the case of error responses from the API. Previously in such cases, callbacks would be called with err=null and the error response in the result parameter. This pull request would have the error response in the err parameter.
  - Possible compatability issues
  - Rationale: besides being less-surprising behavior, this takes advantage of the `retry` library. When performing actions on newly created assemblies, the API sometimes does not recognize that the assembly exists (immediately after the response from "POST /assemblies"). By formally considering failed requests as errors, the request will be repeated until the API recognizes that the new assembly exists.
- The deleteAssembly method now calls its callback with the decoded JSON response from the API, consistent with all other methods, where previously it was called with the HTTP response object from the `request` library. Again, possible compatability issues, although it seems more benign in this case.