### PR TITLE
fix: check path for only direct Readable instances

### DIFF
--- a/src/TransloaditClient.js
+++ b/src/TransloaditClient.js
@@ -5,6 +5,7 @@ const _ = reqr('underscore')
 const fs = reqr('fs')
 const retry = reqr('retry')
 const PaginationStream = reqr('./PaginationStream')
+const Readable = reqr('stream').Readable
 
 let unknownErrMsg = 'Unknown error. Please report this at '
 unknownErrMsg += 'https://github.com/transloadit/node-sdk/issues/new?title=Unknown%20error'
@@ -123,7 +124,7 @@ class TransloaditClient {
     for (stream of Array.from(streams)) {
       stream.on('error', cb)
 
-      if (stream.path == null) {
+      if (stream.path == null || !(stream instanceof Readable)) {
         streamErrCb(null)
         continue
       }

--- a/src/TransloaditClient.js
+++ b/src/TransloaditClient.js
@@ -124,6 +124,9 @@ class TransloaditClient {
     for (stream of Array.from(streams)) {
       stream.on('error', cb)
 
+      // because an http response stream could also have a "path"
+      // attribute but not referring to the local file system
+      // see https://github.com/transloadit/node-sdk/pull/50#issue-261982855
       if (stream.path == null || !(stream instanceof Readable)) {
         streamErrCb(null)
         continue


### PR DESCRIPTION
Before creation of assemblies the node-sdk [tries to check if of the streams added, the ones with the attribute `path` can be accessed via the file system](https://github.com/transloadit/node-sdk/blob/master/src/TransloaditClient.js#L126).

**The Problem:** for the case where the stream is added via the response of a [request module](https://github.com/request/request), this check would break the assembly creation because the request module also has a `path` attribute, but this does not refer to the file system, rather it refers to the url path. So basically, a snippet like this would fail.

`transloadit.addStream('my_file', request('https://myurl.whatever/image.jpg'))`

While I'm not sure what the best solution would be, this PR tries to check if the stream is a direct instanceof [stream.Readable](https://nodejs.org/api/stream.html#stream_class_stream_readable)(which the request instance isn't).
