### PR TITLE
Fix failing test due to version increase

### DIFF
--- a/test/test-transloadit-client.js
+++ b/test/test-transloadit-client.js
@@ -267,7 +267,7 @@ describe('TransloaditClient', () => {
       const client = new TransloaditClient({ authKey: 'foo_key', authSecret: 'foo_secret' })
 
       gently.expect(gently.hijacked.request, 'get', (opts) => {
-        expect(opts.headers).to.eql({'Transloadit-Client': 'node-sdk:2.0.2'})
+        expect(opts.headers).to.eql({'Transloadit-Client': 'node-sdk:2.0.4'})
         return {}
       })
 


### PR DESCRIPTION
The tests on Travis were failing: https://travis-ci.org/transloadit/node-sdk/jobs/454859192#L514

This is not a permanent solution but it solves the test failure for now.