### PR TITLE
Fix Transloadit-Client header test for once and all

### DIFF
--- a/test/test-transloadit-client.js
+++ b/test/test-transloadit-client.js
@@ -2,6 +2,7 @@ const gently = require('./gently-preamble')
 // const should            = require('chai').should()
 const { expect } = require('chai')
 const TransloaditClient = require('../src/TransloaditClient')
+const packageVersion = require('../package.json').version
 
 describe('TransloaditClient', () => {
   describe('constructor', () => {
@@ -267,7 +268,7 @@ describe('TransloaditClient', () => {
       const client = new TransloaditClient({ authKey: 'foo_key', authSecret: 'foo_secret' })
 
       gently.expect(gently.hijacked.request, 'get', (opts) => {
-        expect(opts.headers).to.eql({'Transloadit-Client': 'node-sdk:2.0.4'})
+        expect(opts.headers).to.eql({'Transloadit-Client': 'node-sdk:' + packageVersion})
         return {}
       })
 


### PR DESCRIPTION
This patch fixes the test for the Transloadit-Client header which keeps constantly failing whenever a new version is release. I changed the hardcoded version to a flexible one, so we do not need to change the test for every release.

One example for a failing build is: https://travis-ci.org/transloadit/node-sdk/builds/476280407