### PR TITLE
Upgrade Node versions used for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
+  - "10"
+  - "12"
 script:
-  - if [ "${TRAVIS_NODE_VERSION}" = "7" ]; then npm run lint; fi
+  - npm run lint
   - npm run test
 
 # travis encrypt [subdomain]:[api token]@[room id]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
+  - "11"
   - "12"
+  - "13"
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
~~Hopefully~~ fixes the failing tests: https://travis-ci.org/github/transloadit/node-sdk/builds/663059704

The older Node versions are not supported by our build tools anymore, so the `npm install` would fail.