### PR TITLE
Generate assemblyId on client

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ function onAssemblyProgress(assembly) {
 }
 ```
 
-**Tip:** `createAssembly` returns a `Promise` with an extra property `assemblyId`. This can be used to retrieve the assemblyId before the assembly has even been created. Useful for debugging by logging this ID when the request starts, for example:
+**Tip:** `createAssembly` returns a `Promise` with an extra property `assemblyId`. This can be used to retrieve the Assembly ID before the Assembly has even been created. Useful for debugging by logging this ID when the request starts, for example:
 
 ```js
 const promise = transloadit.createAssembly(options)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ function onAssemblyProgress(assembly) {
 }
 ```
 
+**Tip:** `createAssembly` returns a `Promise` with an extra property `assemblyId`. This can be used to retrieve the assemblyId before the assembly has even been created. Useful for debugging by logging this ID when the request starts, for example:
+
+```js
+const promise = transloadit.createAssembly(options)
+console.log('Creating', promise.assemblyId)
+const status = await promise
+```
+
+
 See also:
 - [API documentation](https://transloadit.com/docs/api/#assemblies-post)
 - Error codes and retry logic below

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "is-stream": "^2.0.0",
     "lodash": "^4.17.20",
     "p-map": "^4.0.0",
-    "tus-js-client": "^2.2.0"
+    "tus-js-client": "^2.2.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@babel/eslint-plugin": "^7.13.10",
@@ -42,8 +43,7 @@
     "p-retry": "^4.2.0",
     "request": "^2.88.2",
     "temp": "^0.9.1",
-    "tsd": "^0.14.0",
-    "uuid": "^8.3.2"
+    "tsd": "^0.14.0"
   },
   "repository": {
     "type": "git",

--- a/test/unit/__tests__/mock-http.js
+++ b/test/unit/__tests__/mock-http.js
@@ -6,6 +6,8 @@ jest.setTimeout(1000)
 
 const getLocalClient = (opts) => new Transloadit({ authKey: '', authSecret: '', endpoint: 'http://localhost', ...opts })
 
+const createAssemblyRegex = /\/assemblies\/[0-9a-f]{32}/
+
 describe('Mocked API tests', () => {
   afterEach(() => {
     nock.cleanAll()
@@ -16,7 +18,7 @@ describe('Mocked API tests', () => {
     const client = new Transloadit({ authKey: '', authSecret: '', endpoint: 'http://localhost' })
 
     nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .delay(100)
       .reply(200)
 
@@ -51,7 +53,7 @@ describe('Mocked API tests', () => {
     const client = getLocalClient()
 
     const scope = nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(200, { ok: 'ASSEMBLY_UPLOADING' })
       .get('/assemblies/1')
       .query(() => true)
@@ -83,7 +85,7 @@ describe('Mocked API tests', () => {
     const client = getLocalClient()
 
     nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(400, { error: 'INVALID_FILE_META_DATA' })
 
     await expect(client.createAssembly()).rejects.toThrow(expect.objectContaining({ transloaditErrorCode: 'INVALID_FILE_META_DATA', message: 'INVALID_FILE_META_DATA' }))
@@ -93,7 +95,7 @@ describe('Mocked API tests', () => {
     const client = getLocalClient()
 
     nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(400, { error: 'INVALID_FILE_META_DATA', assembly_id: '123', assembly_ssl_url: 'https://api2-oltu.transloadit.com/assemblies/foo' })
 
     await expect(client.createAssembly()).rejects.toThrow(expect.objectContaining({
@@ -111,9 +113,9 @@ describe('Mocked API tests', () => {
     // https://transloadit.com/blog/2012/04/introducing-rate-limiting/
 
     const scope = nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(413, { error: 'RATE_LIMIT_REACHED', info: { retryIn: 0.01 } })
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(200, { ok: 'ASSEMBLY_EXECUTING' })
 
     await client.createAssembly()
@@ -124,7 +126,7 @@ describe('Mocked API tests', () => {
     const client = getLocalClient({ maxRetries: 0 })
 
     const scope = nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(413, { error: 'RATE_LIMIT_REACHED', message: 'Request limit reached', info: { retryIn: 0.01 } })
 
     await expect(client.createAssembly()).rejects.toThrow(expect.objectContaining({ transloaditErrorCode: 'RATE_LIMIT_REACHED', message: 'RATE_LIMIT_REACHED: Request limit reached' }))
@@ -190,7 +192,7 @@ describe('Mocked API tests', () => {
     const client = getLocalClient()
 
     const scope = nock('http://localhost')
-      .post('/assemblies')
+      .post(createAssemblyRegex)
       .reply(200, { error: 'IMPORT_FILE_ERROR', assembly_id: '1' })
 
     await expect(client.createAssembly()).rejects.toThrow(expect.objectContaining({

--- a/test/unit/__tests__/test-transloadit-client.js
+++ b/test/unit/__tests__/test-transloadit-client.js
@@ -207,7 +207,7 @@ describe('Transloadit', () => {
   it('should crash if attempt to use callback', async () => {
     const client = new Transloadit({ authKey: 'foo_key', authSecret: 'foo_secret' })
     const cb = () => {}
-    await expect(client.createAssembly({}, cb)).rejects.toThrow(TypeError)
+    expect(() => client.createAssembly({}, cb)).toThrow(TypeError)
   })
 
   describe('_calcSignature', () => {


### PR DESCRIPTION
Generate assemblyId on client and allow user to retrieve it by calling `promise.assemblyId` on the returned promise from `createAssembly`.
This allows the user to use or log the assemblyId even before it has been created for easier debugging.

As far as I can tell, this is not a breaking change, but could theoretically be breaking if user does expects it to throw this error synchronously (which they shouldn't) **if errornously passing a cb to createAssembly**:
`createAssembly(params, cb).then(...).catch(...)`

It will now throw `TypeError('You are trying to send a function as the second argument....')` **synchronously** (immediately) instead of rejecting the promise with this error (as it did prior to this PR)

See this change https://github.com/transloadit/node-sdk/pull/106/files#diff-dd8bbf53773ba61b55737b8b5e48fac40e1acc419726f9648c0816bf430f7314