### PR TITLE
Use tus for all uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ You can provide the following keys inside the `options` object:
   - `totalBytes` - Total number of bytes to upload or `undefined` if unknown (Streams).
 - `onAssemblyProgress` - Once the Assembly has started processing this will be periodically called with the *Assembly Execution Status* (result of `getAssembly`) **only if `waitForCompletion` is `true`**.
 - `chunkSize` - (for uploads) a number indicating the maximum size of a TUS `PATCH` request body in bytes. Default to `Infinity` for file uploads and 5MB for streams of unknown length. See [tus-js-client](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
+- `uploadConcurrency` - Maximum number of concurrent tus file uploads to occur at any given time (default 10.)
 
 Example code showing all options:
 ```js

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ You can provide the following keys inside the `options` object:
   - `uploadedBytes` - Number of bytes uploaded so far.
   - `totalBytes` - Total number of bytes to upload or `undefined` if unknown (Streams).
 - `onAssemblyProgress` - Once the Assembly has started processing this will be periodically called with the *Assembly Execution Status* (result of `getAssembly`) **only if `waitForCompletion` is `true`**.
-- `chunkSize` - (for uploads) a number indicating the maximum size of a TUS `PATCH` request body in bytes. Default to `Infinity` for file uploads and 5MB for streams of unknown length. See [tus-js-client](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
+- `chunkSize` - (for uploads) a number indicating the maximum size of a tus `PATCH` request body in bytes. Default to `Infinity` for file uploads and 50MB for streams of unknown length. See [tus-js-client](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
 - `uploadConcurrency` - Maximum number of concurrent tus file uploads to occur at any given time (default 10.)
 
 Example code showing all options:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ You can provide the following keys inside the `options` object:
   - `uploadedBytes` - Number of bytes uploaded so far.
   - `totalBytes` - Total number of bytes to upload or `undefined` if unknown (Streams).
 - `onAssemblyProgress` - Once the Assembly has started processing this will be periodically called with the *Assembly Execution Status* (result of `getAssembly`) **only if `waitForCompletion` is `true`**.
+- `chunkSize` - (for uploads) a number indicating the maximum size of a TUS `PATCH` request body in bytes. Default to `Infinity` for file uploads and 5MB for streams of unknown length. See [tus-js-client](https://github.com/tus/tus-js-client/blob/master/docs/api.md#chunksize).
 
 Example code showing all options:
 ```js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "is-stream": "^2.0.0",
     "lodash": "^4.17.20",
     "p-map": "^4.0.0",
-    "tus-js-client": "^2.2.0",
+    "tus-js-client": "^2.3.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -2,11 +2,8 @@ const got = require('got')
 const FormData = require('form-data')
 const crypto = require('crypto')
 const fromPairs = require('lodash/fromPairs')
-const sumBy = require('lodash/sumBy')
 const fs = require('fs')
-const { basename } = require('path')
-const tus = require('tus-js-client')
-const { access, stat: fsStat } = require('fs').promises
+const { access } = require('fs').promises
 const log = require('debug')('transloadit')
 const logWarn = require('debug')('transloadit:warn')
 const intoStream = require('into-stream')
@@ -17,6 +14,7 @@ const uuid = require('uuid')
 
 const PaginationStream = require('./PaginationStream')
 const { version } = require('../package.json')
+const { sendTusRequest } = require('./tus')
 
 function decorateError (err, body) {
   if (!body) return err
@@ -51,8 +49,6 @@ function checkAssemblyUrls (result) {
   }
 }
 
-const isFileBasedStream = (stream) => !!stream.path
-
 function getHrTimeMs () {
   return Number(process.hrtime.bigint() / 1000000n)
 }
@@ -68,73 +64,6 @@ function checkResult (result) {
     }
     throw decorateError(err, result)
   }
-}
-
-async function sendTusRequest ({ streamsMap, assembly, onProgress }) {
-  const streamLabels = Object.keys(streamsMap)
-
-  let totalBytes = 0
-  let lastEmittedProgress = 0
-
-  const sizes = {}
-
-  // Initialize data
-  await pMap(streamLabels, async (label) => {
-    const { path } = streamsMap[label]
-
-    if (path) {
-      const { size } = await fsStat(path)
-      sizes[label] = size
-      totalBytes += size
-    }
-  }, { concurrency: 5 })
-
-  const uploadProgresses = {}
-
-  async function uploadSingleStream (label) {
-    uploadProgresses[label] = 0
-
-    const { stream, path } = streamsMap[label]
-    const size = sizes[label]
-
-    const onTusProgress = (bytesUploaded) => {
-      uploadProgresses[label] = bytesUploaded
-
-      // get all uploaded bytes for all files
-      const uploadedBytes = sumBy(streamLabels, (l) => uploadProgresses[l])
-
-      // don't send redundant progress
-      if (lastEmittedProgress < uploadedBytes) {
-        lastEmittedProgress = uploadedBytes
-        onProgress({ uploadedBytes, totalBytes })
-      }
-    }
-
-    const filename = path ? basename(path) : label
-
-    await new Promise((resolve, reject) => {
-      const tusUpload = new tus.Upload(stream, {
-        endpoint: assembly.tus_url,
-        metadata: {
-          assembly_url: assembly.assembly_ssl_url,
-          fieldname   : label,
-          filename,
-        },
-        uploadSize: size,
-        onError   : reject,
-        onProgress: onTusProgress,
-        onSuccess : resolve,
-      })
-
-      tusUpload.start()
-    })
-
-    log(label, 'upload done')
-  }
-
-  // TODO throttle concurrency? Can use p-map
-  const promises = streamLabels.map((label) => uploadSingleStream(label))
-  await Promise.all(promises)
 }
 
 class TransloaditClient {
@@ -184,6 +113,7 @@ class TransloaditClient {
       params = {},
       waitForCompletion = false,
       isResumable = true,
+      chunkSize: requestedChunkSize = Infinity,
       timeout = 24 * 60 * 60 * 1000, // 1 day
       onUploadProgress = () => {},
       onAssemblyProgress = () => {},
@@ -191,6 +121,10 @@ class TransloaditClient {
       uploads = {},
       assemblyId,
     } = opts
+
+    if (!isResumable) {
+      process.emitWarning('Parameter value isResumable = false is deprecated. All uploads will be resumable (using TUS) in the future', 'DeprecationWarning')
+    }
 
     // Keep track of how long the request took
     const startTimeMs = getHrTimeMs()
@@ -247,8 +181,6 @@ class TransloaditClient {
       })
 
       const createAssemblyAndUpload = async () => {
-        const useTus = isResumable && allStreams.every(isFileBasedStream)
-
         const requestOpts = {
           urlSuffix,
           method: 'post',
@@ -256,26 +188,24 @@ class TransloaditClient {
           params,
         }
 
-        if (useTus) {
+        if (isResumable) {
           requestOpts.fields = {
             tus_num_expected_upload_files: allStreams.length,
           }
-        } else if (isResumable) {
-          logWarn('Disabling resumability because the size of one or more streams cannot be determined')
         }
 
         // upload as form multipart or tus?
-        const formUploadStreamsMap = useTus ? {} : allStreamsMap
-        const tusStreamsMap = useTus ? allStreamsMap : {}
+        const formUploadStreamsMap = isResumable ? {} : allStreamsMap
 
         const result = await this._remoteJson(requestOpts, formUploadStreamsMap, onUploadProgress)
         checkResult(result)
 
-        if (useTus && Object.keys(tusStreamsMap).length > 0) {
+        if (isResumable && Object.keys(allStreamsMap).length > 0) {
           await sendTusRequest({
-            streamsMap: tusStreamsMap,
+            streamsMap: allStreamsMap,
             assembly  : result,
             onProgress: onUploadProgress,
+            requestedChunkSize,
           })
         }
 

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -114,6 +114,7 @@ class TransloaditClient {
       waitForCompletion = false,
       isResumable = true,
       chunkSize: requestedChunkSize = Infinity,
+      uploadConcurrency = 10,
       timeout = 24 * 60 * 60 * 1000, // 1 day
       onUploadProgress = () => {},
       onAssemblyProgress = () => {},
@@ -206,6 +207,7 @@ class TransloaditClient {
             assembly  : result,
             onProgress: onUploadProgress,
             requestedChunkSize,
+            uploadConcurrency,
           })
         }
 

--- a/src/tus.js
+++ b/src/tus.js
@@ -5,7 +5,7 @@ const tus = require('tus-js-client')
 const { stat: fsStat } = require('fs').promises
 const pMap = require('p-map')
 
-async function sendTusRequest ({ streamsMap, assembly, requestedChunkSize, onProgress }) {
+async function sendTusRequest ({ streamsMap, assembly, requestedChunkSize, uploadConcurrency, onProgress }) {
   const streamLabels = Object.keys(streamsMap)
 
   let totalBytes = 0
@@ -89,9 +89,7 @@ async function sendTusRequest ({ streamsMap, assembly, requestedChunkSize, onPro
     log(label, 'upload done')
   }
 
-  // TODO throttle concurrency? Can use p-map
-  const promises = streamLabels.map((label) => uploadSingleStream(label))
-  await Promise.all(promises)
+  await pMap(streamLabels, uploadSingleStream, { concurrency: uploadConcurrency })
 }
 
 module.exports = {

--- a/src/tus.js
+++ b/src/tus.js
@@ -41,7 +41,7 @@ async function sendTusRequest ({ streamsMap, assembly, requestedChunkSize, uploa
       // tus-js-client requires these options to be set for unknown size streams
       // https://github.com/tus/tus-js-client/blob/master/docs/api.md#uploadlengthdeferred
       uploadLengthDeferred = true
-      if (chunkSize === Infinity) chunkSize = 5e6
+      if (chunkSize === Infinity) chunkSize = 50e6
     }
 
     const onTusProgress = (bytesUploaded) => {

--- a/src/tus.js
+++ b/src/tus.js
@@ -1,0 +1,99 @@
+const log = require('debug')('transloadit')
+const sumBy = require('lodash/sumBy')
+const { basename } = require('path')
+const tus = require('tus-js-client')
+const { stat: fsStat } = require('fs').promises
+const pMap = require('p-map')
+
+async function sendTusRequest ({ streamsMap, assembly, requestedChunkSize, onProgress }) {
+  const streamLabels = Object.keys(streamsMap)
+
+  let totalBytes = 0
+  let lastEmittedProgress = 0
+
+  const sizes = {}
+
+  const haveUnknownLengthStreams = streamLabels.some((label) => !streamsMap[label].path)
+
+  // Initialize size data
+  await pMap(streamLabels, async (label) => {
+    const { path } = streamsMap[label]
+
+    if (path) {
+      const { size } = await fsStat(path)
+      sizes[label] = size
+      totalBytes += size
+    }
+  }, { concurrency: 5 })
+
+  const uploadProgresses = {}
+
+  async function uploadSingleStream (label) {
+    uploadProgresses[label] = 0
+
+    const { stream, path } = streamsMap[label]
+    const size = sizes[label]
+
+    let chunkSize = requestedChunkSize
+    let uploadLengthDeferred
+    const isStreamLengthKnown = !!path
+    if (!isStreamLengthKnown) {
+      // tus-js-client requires these options to be set for unknown size streams
+      // https://github.com/tus/tus-js-client/blob/master/docs/api.md#uploadlengthdeferred
+      uploadLengthDeferred = true
+      if (chunkSize === Infinity) chunkSize = 5e6
+    }
+
+    const onTusProgress = (bytesUploaded) => {
+      uploadProgresses[label] = bytesUploaded
+
+      // get all uploaded bytes for all files
+      const uploadedBytes = sumBy(streamLabels, (l) => uploadProgresses[l])
+
+      // don't send redundant progress
+      if (lastEmittedProgress < uploadedBytes) {
+        lastEmittedProgress = uploadedBytes
+        // If we have any unknown length streams, we cannot trust totalBytes
+        // totalBytes should then be undefined to mimic behavior of form uploads.
+        onProgress({
+          uploadedBytes,
+          totalBytes: haveUnknownLengthStreams ? undefined : totalBytes,
+        })
+      }
+    }
+
+    const filename = path ? basename(path) : label
+
+    await new Promise((resolve, reject) => {
+      const tusOptions = {
+        endpoint: assembly.tus_url,
+        metadata: {
+          assembly_url: assembly.assembly_ssl_url,
+          fieldname   : label,
+          filename,
+        },
+        uploadSize: size,
+        onError   : reject,
+        onProgress: onTusProgress,
+        onSuccess : resolve,
+      }
+      // tus-js-client doesn't like undefined/null
+      if (chunkSize) tusOptions.chunkSize = chunkSize
+      if (uploadLengthDeferred) tusOptions.uploadLengthDeferred = uploadLengthDeferred
+
+      const tusUpload = new tus.Upload(stream, tusOptions)
+
+      tusUpload.start()
+    })
+
+    log(label, 'upload done')
+  }
+
+  // TODO throttle concurrency? Can use p-map
+  const promises = streamLabels.map((label) => uploadSingleStream(label))
+  await Promise.all(promises)
+}
+
+module.exports = {
+  sendTusRequest,
+}

--- a/test/unit/__tests__/test-transloadit-client.js
+++ b/test/unit/__tests__/test-transloadit-client.js
@@ -2,12 +2,17 @@ const { Readable: ReadableStream } = require('stream')
 const FormData = require('form-data')
 const got = require('got')
 
+jest.mock('../../../src/tus')
+
+const tus = require('../../../src/tus')
 const Transloadit = require('../../../src/Transloadit')
 const packageVersion = require('../../../package.json').version
 
 /* eslint-disable no-underscore-dangle */
 
 jest.mock('got')
+
+tus.sendTusRequest.mockImplementation(() => {})
 
 const mockedExpiresDate = '2021-01-06T21:11:07.883Z'
 const mockGetExpiresDate = (client) => jest.spyOn(client, '_getExpiresDate').mockReturnValue(mockedExpiresDate)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ export default class Transloadit {
     }
     waitForCompletion?: boolean,
     isResumable?: boolean,
+    chunkSize?: number,
     timeout?: number
     onUploadProgress?: (uploadProgress: UploadProgress) => void,
     onAssemblyProgress?: AssemblyProgress,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,7 @@ export default class Transloadit {
     waitForCompletion?: boolean,
     isResumable?: boolean,
     chunkSize?: number,
+    uploadConcurrency?: number,
     timeout?: number
     onUploadProgress?: (uploadProgress: UploadProgress) => void,
     onAssemblyProgress?: AssemblyProgress,

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,6 +27,7 @@ expectType<Promise<Assembly>>(transloadit.createAssembly({
     file4: Buffer.from('string'),
   },
   isResumable: true,
+  chunkSize: Infinity,
   timeout: 1,
   waitForCompletion: true,
   onAssemblyProgress: (assembly) => {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -28,6 +28,7 @@ expectType<Promise<Assembly>>(transloadit.createAssembly({
   },
   isResumable: true,
   chunkSize: Infinity,
+  uploadConcurrency: 5,
   timeout: 1,
   waitForCompletion: true,
   onAssemblyProgress: (assembly) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5771,13 +5771,14 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tus-js-client@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tus-js-client/-/tus-js-client-2.2.0.tgz#353db7cba7b84b46188b02fa1295344f0b483c4c"
-  integrity sha512-6RM7SHJD1j3X4o+f8dX1tcPOETsSitbF+ee3Ecz4Lu5+muYJnyYMRUXbz12N7dDfoCQ14Y5EmksbDP4BGzmC8w==
+tus-js-client@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tus-js-client/-/tus-js-client-2.3.0.tgz#5d76145476cea46a4e7c045a0054637cddf8dc39"
+  integrity sha512-I4cSwm6N5qxqCmBqenvutwSHe9ntf81lLrtf6BmLpG2v4wTl89atCQKqGgqvkodE6Lx+iKIjMbaXmfvStTg01g==
   dependencies:
     buffer-from "^0.1.1"
     combine-errors "^3.0.3"
+    is-stream "^2.0.0"
     js-base64 "^2.6.1"
     lodash.throttle "^4.1.1"
     proper-lockfile "^2.0.1"


### PR DESCRIPTION
Now that tusd supports uploading unknown length streams, change the internal logic so that we use tus instead of form uploads.

Fixes #88

- Pull out sendTusRequest into separate module so it can be mocked
- Add argument chunkSize (defaults to 5MB only for unknown length streams, Infinity for file streams, same as tus-js-client)
- Emit deprecation warning when isResumable is set to false

This *should* not be a breaking change as we will just swap the internal implementation from form upload to TUS, which normally shouldn't affect users, however there might of course be some edge cases where it differs. So I'm thinking this can be a minor version, or do you think it should be a major version bump? I think deprecating `isResumable: false` is OK for a minor version bump.

NOTE: This PR cannot be merged yet, because https://github.com/tus/tus-js-client/issues/229 is not yet released.

- [x] Need to first release a new version of tus-js-client @Acconut
- [x] then bump tus-js-client in node-sdk.

I tested with tus-js-client from master and all unit/integration tests in node-sdk succeed then.