### PR TITLE
Expose an (undocumented) constructor option `gotRetry`

### DIFF
--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -86,6 +86,9 @@ class TransloaditClient {
     this._maxRetries = opts.maxRetries != null ? opts.maxRetries : 5
     this._defaultTimeout = opts.timeout != null ? opts.timeout : 60000
 
+    // Passed on to got https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md
+    this._gotRetry = opts.gotRetry != null ? opts.gotRetry : 0
+
     this._lastUsedAssemblyUrl = ''
   }
 
@@ -572,7 +575,7 @@ class TransloaditClient {
       const isUploadingStreams = streamsMap && Object.keys(streamsMap).length > 0
 
       const requestOpts = {
-        retry  : 0,
+        retry  : this._gotRetry,
         body   : form,
         timeout,
         headers: {

--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -34,7 +34,32 @@ function createClient (opts = {}) {
     throw new Error('Please specify environment variables TRANSLOADIT_KEY and TRANSLOADIT_SECRET')
   }
 
-  return new Transloadit({ authKey, authSecret, ...opts })
+  // https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md#retry
+  const gotRetry = {
+    limit  : 2,
+    methods: [
+      'GET',
+      'PUT',
+      'HEAD',
+      'DELETE',
+      'OPTIONS',
+      'TRACE',
+      'POST', // Normally we shouldn't retry on POST, as it is not idempotent, but for tests we can do it
+    ],
+    statusCodes: [],
+    errorCodes : [
+      'ETIMEDOUT',
+      'ECONNRESET',
+      'EADDRINUSE',
+      'ECONNREFUSED',
+      'EPIPE',
+      'ENOTFOUND',
+      'ENETUNREACH',
+      'EAI_AGAIN',
+    ],
+  }
+
+  return new Transloadit({ authKey, authSecret, gotRetry, ...opts })
 }
 
 function createAssembly (client, params) {


### PR DESCRIPTION
Allows us to add retries to our integration tests on network issues