### PR TITLE
Test fixes

### DIFF
--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -594,7 +594,6 @@ describe('API integration', () => {
         const promise = createAssembly(client, { params: { ...genericParams, notify_url: server.url } })
         await promise
         const result = await client.getAssembly(promise.assemblyId)
-        console.log('created', JSON.stringify(result))
       } catch (err) {
         onError(err)
       }
@@ -625,7 +624,6 @@ describe('API integration', () => {
         await new Promise((resolve) => setTimeout(resolve, 1000))
 
         const result = await client.getAssembly(assemblyId)
-        console.log(result)
 
         expect(result.notify_status).toBe('successful')
         expect(result.notify_response_code).toBe(200)
@@ -633,8 +631,8 @@ describe('API integration', () => {
         if (secondNotification) {
           expect(path).toBe(newPath)
 
-          // For some reason, notify_url doesn't get updated to new URL
-          // expect(result.notify_url).toBe(newUrl)
+          // notify_url will not get updated to new URL
+          expect(result.notify_url).toBe(server.url)
 
           try {
             // If we quit immediately, things will not get cleaned up and jest will hang
@@ -654,7 +652,6 @@ describe('API integration', () => {
           expect(result.notify_url).toBe(server.url)
 
           await new Promise((resolve) => setTimeout(resolve, 2000))
-          console.log('replaying')
           await client.replayAssemblyNotification(assemblyId, { notify_url: newUrl })
         } catch (err) {
           done(err)

--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -591,9 +591,7 @@ describe('API integration', () => {
 
       try {
         server = await startServerAsync(onNotificationRequest)
-        const promise = createAssembly(client, { params: { ...genericParams, notify_url: server.url } })
-        await promise
-        const result = await client.getAssembly(promise.assemblyId)
+        await createAssembly(client, { params: { ...genericParams, notify_url: server.url } })
       } catch (err) {
         onError(err)
       }

--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -387,7 +387,7 @@ describe('API integration', () => {
     })
 
     it('should exit fast when assembly has failed', async () => {
-      // An old bug caused it to continuously retry until timeout when errors such as INVALID_FILE_META_DATA
+      // An old bug caused it to continuously retry until timeout when errors such as INVALID_FILE_META_DATA (now INTERNAL_COMMAND_ERROR)
       // Note: This test sometimes reproduces the case where the server returns 200 but with an "error" in the response
       const client = createClient()
       const opts = {
@@ -404,7 +404,7 @@ describe('API integration', () => {
 
       const promise = createAssembly(client, opts)
       await promise.catch((err) => {
-        expect(err).toMatchObject({ transloaditErrorCode: 'INVALID_FILE_META_DATA', assemblyId: expect.any(String) })
+        expect(err).toMatchObject({ transloaditErrorCode: 'INTERNAL_COMMAND_ERROR', assemblyId: expect.any(String) })
       })
       await expect(promise).rejects.toThrow(Error)
     }, 7000)


### PR DESCRIPTION
This PR contains the updated response code assertion for empty files INVALID_FILE_META_DATA -> INTERNAL_COMMAND_ERROR

I also re-introduced assertions that were removed previously when the list assembly notifications API was removed. Will now assembly `assembly.notify_url` instead.

NOTE: when replaying an assembly notification with a **different** notify_url, the assembly status `assembly.notify_url` **does not get updated to the new value**. Is this working as intended?