### PR TITLE
fix assertion

### DIFF
--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -623,7 +623,7 @@ describe('API integration', () => {
 
         const result = await client.getAssembly(assemblyId)
 
-        expect(result.notify_status).toBe('successful')
+        expect(['successful', 'processing']).toContain(result.notify_status);
         expect(result.notify_response_code).toBe(200)
 
         if (secondNotification) {

--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -623,7 +623,7 @@ describe('API integration', () => {
 
         const result = await client.getAssembly(assemblyId)
 
-        expect(['successful', 'processing']).toContain(result.notify_status);
+        expect(['successful', 'processing']).toContain(result.notify_status)
         expect(result.notify_response_code).toBe(200)
 
         if (secondNotification) {


### PR DESCRIPTION
```
  ● API integration › assembly notification › should replay the notification when requested

    expect(received).toBe(expected) // Object.is equality

    Expected: "successful"
    Received: "processing"

      624 |         const result = await client.getAssembly(assemblyId)
      625 | 
    > 626 |         expect(result.notify_status).toBe('successful')
          |                                      ^
      627 |         expect(result.notify_response_code).toBe(200)
      628 | 
      629 |         if (secondNotification) {

      at onNotification (test/integration/__tests__/live-api.js:626:38)
```

https://github.com/transloadit/node-sdk/runs/5437493315?check_suite_focus=true