### PR TITLE
increase test timeout

### DIFF
--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -387,7 +387,8 @@ describe('API integration', () => {
     })
 
     it('should exit fast when assembly has failed', async () => {
-      // An old bug caused it to continuously retry until timeout when errors such as INVALID_FILE_META_DATA (now INTERNAL_COMMAND_ERROR)
+      // An old bug caused it to continuously retry until timeout when errors such as
+      // INVALID_FILE_META_DATA (now INTERNAL_COMMAND_ERROR)
       // Note: This test sometimes reproduces the case where the server returns 200 but with an "error" in the response
       const client = createClient()
       const opts = {
@@ -407,7 +408,7 @@ describe('API integration', () => {
         expect(err).toMatchObject({ transloaditErrorCode: 'INTERNAL_COMMAND_ERROR', assemblyId: expect.any(String) })
       })
       await expect(promise).rejects.toThrow(Error)
-    }, 7000)
+    }, 60000)
   })
 
   describe('assembly cancelation', () => {


### PR DESCRIPTION
to try to remedy flaky test

https://github.com/transloadit/node-sdk/runs/5566549380?check_suite_focus=true

([the assembly](https://transloadit.com/c/open-test-prod/assemblies/40c7867e0f774c0c8b6c492e6d527e53) took 8.304sec)

again: https://github.com/transloadit/node-sdk/runs/5623688268?check_suite_focus=true