### PR TITLE
remove assembly progress assertion

### DIFF
--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -159,7 +159,8 @@ describe('API integration', () => {
       const options = {
         ...genericOptions,
         onUploadProgress: (uploadProgress) => { uploadProgressCalled = uploadProgress },
-        // Assemblies no longer consistently emit progress
+        // Often an assembly will finish before the node-sdk has time to emit an onAssemblyProgress event,
+        // so we cannot rely on that (will cause unstable tests)
         // onAssemblyProgress: (assemblyProgress) => { assemblyProgressCalled = assemblyProgress },
       }
       let result = await createAssembly(client, options)

--- a/test/integration/__tests__/live-api.js
+++ b/test/integration/__tests__/live-api.js
@@ -156,11 +156,11 @@ describe('API integration', () => {
       const client = createClient()
 
       let uploadProgressCalled
-      let assemblyProgressCalled
       const options = {
         ...genericOptions,
-        onUploadProgress  : (uploadProgress) => { uploadProgressCalled = uploadProgress },
-        onAssemblyProgress: (assemblyProgress) => { assemblyProgressCalled = assemblyProgress },
+        onUploadProgress: (uploadProgress) => { uploadProgressCalled = uploadProgress },
+        // Assemblies no longer consistently emit progress
+        // onAssemblyProgress: (assemblyProgress) => { assemblyProgressCalled = assemblyProgress },
       }
       let result = await createAssembly(client, options)
       expect(result).not.toHaveProperty('error')
@@ -168,7 +168,6 @@ describe('API integration', () => {
       expect(result).toHaveProperty('assembly_id') // Since we're using it
 
       expect(uploadProgressCalled).toBeUndefined()
-      expect(assemblyProgressCalled).toMatchObject({ assembly_id: result.assembly_id })
 
       const id = result.assembly_id
 


### PR DESCRIPTION
Assemblies no longer seem to consistently emit progress

See failed test runs:
- https://github.com/transloadit/node-sdk/runs/5767629359?check_suite_focus=true
- https://github.com/transloadit/node-sdk/runs/5784606211?check_suite_focus=true
- https://github.com/transloadit/node-sdk/runs/5798550618?check_suite_focus=true
- https://github.com/transloadit/node-sdk/runs/5804663978?check_suite_focus=true