### PR TITLE
decorate also err.stack with transloadit response

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": true
 }

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -10,7 +10,7 @@ const intoStream = require('into-stream')
 const isStream = require('is-stream')
 const assert = require('assert')
 const pMap = require('p-map')
-const uuid = require('uuid');
+const uuid = require('uuid')
 
 const InconsistentResponseError = require('./InconsistentResponseError')
 const PaginationStream = require('./PaginationStream')
@@ -31,7 +31,7 @@ function decorateHttpError(err, body) {
 
   if (typeof err.stack === 'string') {
     const indexOfMessageEnd = err.stack.indexOf(err.message) + err.message.length
-    const stacktrace = err.stack.slice(indexOfMessageEnd);
+    const stacktrace = err.stack.slice(indexOfMessageEnd)
     newStack = `${newMessage}${stacktrace}`
   }
 

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -10,25 +10,34 @@ const intoStream = require('into-stream')
 const isStream = require('is-stream')
 const assert = require('assert')
 const pMap = require('p-map')
-const uuid = require('uuid')
+const uuid = require('uuid');
 
 const InconsistentResponseError = require('./InconsistentResponseError')
 const PaginationStream = require('./PaginationStream')
 const { version } = require('../package.json')
 const { sendTusRequest } = require('./tus')
 
-function decorateError(err, body) {
+function decorateHttpError(err, body) {
   if (!body) return err
-  let { message } = err
+
+  let newMessage = err.message
+  let newStack = err.stack
 
   // Provide a more useful message if there is one
-  if (body.message && body.error) message = `${body.error}: ${body.message}`
-  else if (body.error) message = body.error
+  if (body.message && body.error) newMessage += ` ${body.error}: ${body.message}`
+  else if (body.error) newMessage += ` ${body.error}`
 
-  if (body.assembly_ssl_url) message += ` - ${body.assembly_ssl_url}`
+  if (body.assembly_ssl_url) newMessage += ` - ${body.assembly_ssl_url}`
+
+  if (typeof err.stack === 'string') {
+    const indexOfMessageEnd = err.stack.indexOf(err.message) + err.message.length
+    const stacktrace = err.stack.slice(indexOfMessageEnd);
+    newStack = `${newMessage}${stacktrace}`
+  }
 
   /* eslint-disable no-param-reassign */
-  err.message = message
+  err.message = newMessage
+  err.stack = newStack
   if (body.assembly_id) err.assemblyId = body.assembly_id
   if (body.error) err.transloaditErrorCode = body.error
   /* eslint-enable no-param-reassign */
@@ -56,7 +65,7 @@ function checkResult(result) {
     err.response = {
       body: result,
     }
-    throw decorateError(err, result)
+    throw decorateHttpError(err, result)
   }
 }
 
@@ -705,7 +714,7 @@ class TransloaditClient {
           retryCount < this._maxRetries
 
         // https://transloadit.com/blog/2012/04/introducing-rate-limiting/
-        if (!shouldRetry) throw decorateError(err, body)
+        if (!shouldRetry) throw decorateHttpError(err, body)
 
         const { retryIn: retryInSec } = body.info
         logWarn(`Rate limit reached, retrying request in approximately ${retryInSec} seconds.`)

--- a/test/unit/__tests__/mock-http.js
+++ b/test/unit/__tests__/mock-http.js
@@ -107,7 +107,8 @@ describe('Mocked API tests', () => {
     await expect(client.createAssembly()).rejects.toThrow(
       expect.objectContaining({
         assemblyId: '123',
-        message: 'Response code 400 (Bad Request) INVALID_FILE_META_DATA - https://api2-oltu.transloadit.com/assemblies/foo',
+        message:
+          'Response code 400 (Bad Request) INVALID_FILE_META_DATA - https://api2-oltu.transloadit.com/assemblies/foo',
         response: expect.objectContaining({
           body: expect.objectContaining({ assembly_id: '123' }),
         }),

--- a/test/unit/__tests__/mock-http.js
+++ b/test/unit/__tests__/mock-http.js
@@ -90,7 +90,7 @@ describe('Mocked API tests', () => {
     await expect(client.createAssembly()).rejects.toThrow(
       expect.objectContaining({
         transloaditErrorCode: 'INVALID_FILE_META_DATA',
-        message: 'INVALID_FILE_META_DATA',
+        message: 'Response code 400 (Bad Request) INVALID_FILE_META_DATA',
       })
     )
   })
@@ -107,7 +107,7 @@ describe('Mocked API tests', () => {
     await expect(client.createAssembly()).rejects.toThrow(
       expect.objectContaining({
         assemblyId: '123',
-        message: 'INVALID_FILE_META_DATA - https://api2-oltu.transloadit.com/assemblies/foo',
+        message: 'Response code 400 (Bad Request) INVALID_FILE_META_DATA - https://api2-oltu.transloadit.com/assemblies/foo',
         response: expect.objectContaining({
           body: expect.objectContaining({ assembly_id: '123' }),
         }),
@@ -145,7 +145,7 @@ describe('Mocked API tests', () => {
     await expect(client.createAssembly()).rejects.toThrow(
       expect.objectContaining({
         transloaditErrorCode: 'RATE_LIMIT_REACHED',
-        message: 'RATE_LIMIT_REACHED: Request limit reached',
+        message: 'Response code 413 (Payload Too Large) RATE_LIMIT_REACHED: Request limit reached',
       })
     )
     scope.done()


### PR DESCRIPTION
closes #161

I also updated err.message to [include more useful info](https://github.com/transloadit/node-sdk/pull/162/commits/8abeb8bfdc7a1ad5b85a0b1b6e0b59b6cbb6e53f). Not sure if that's considered a breaking change, but I think not, because who parses err.message?