### PR TITLE
Update the Transloadit's logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-<a href="https://transloadit.com/?utm_source=github&utm_medium=referral&utm_campaign=sdks&utm_content=node_sdk">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
-    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
-  </picture>
-</a>
+<div style="text-align: center;">
+  <a href="https://transloadit.com/?utm_source=github&utm_medium=referral&utm_campaign=sdks&utm_content=node_sdk">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+      <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+    </picture>
+  </a>
 
-This is the official **Node.js** SDK for [Transloadit](https://transloadit.com)'s file uploading and encoding service.
+  <p>This is the official <strong>Node.js</strong> SDK for <a href="https://transloadit.com">Transloadit</a>'s file uploading and encoding service.</p>
 
-[![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
+  <p>
+    <a href="https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests"><img src="https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg"></a>
+    <a href="https://transloadit.github.io/node-sdk-coverage"><img src="https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg"></a>
+  </p>
+</div>
 
 ## Intro
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   </picture>
 </a>
 
+* * *
+
 [![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 
 This is the official **Node.js** SDK for [Transloadit](https://transloadit.com)'s file uploading and encoding service.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
     <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
   </picture>
 </a>
-
-* * *
+<hr>
 
 [![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,14 @@
-<div style="text-align: center;">
-  <a href="https://transloadit.com/?utm_source=github&utm_medium=referral&utm_campaign=sdks&utm_content=node_sdk">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
-      <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
-    </picture>
-  </a>
+<a href="https://transloadit.com/?utm_source=github&utm_medium=referral&utm_campaign=sdks&utm_content=node_sdk">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+  </picture>
+</a>
 
-  <p>This is the official <strong>Node.js</strong> SDK for <a href="https://transloadit.com">Transloadit</a>'s file uploading and encoding service.</p>
+This is the official **Node.js** SDK for [Transloadit](https://transloadit.com)'s file uploading and encoding service.
 
-  <p>
-    <a href="https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests"><img src="https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg"></a>
-    <a href="https://transloadit.github.io/node-sdk-coverage"><img src="https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg"></a>
-  </p>
-</div>
+[![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 
 ## Intro
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-<img src="logo.svg" width="400" />
+<a href="https://transloadit.com/?utm_source=github&utm_medium=referral&utm_campaign=sdks&utm_content=node_sdk">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+  </picture>
+</a>
 
 [![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,10 @@
     <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
   </picture>
 </a>
-<hr>
-
-[![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 
 This is the official **Node.js** SDK for [Transloadit](https://transloadit.com)'s file uploading and encoding service.
+
+[![](https://github.com/transloadit/node-sdk/workflows/Tests/badge.svg)](https://github.com/transloadit/node-sdk/actions?query=workflow%3ATests) [![](https://transloadit.github.io/node-sdk-coverage/coverage-badge.svg)](https://transloadit.github.io/node-sdk-coverage)
 
 ## Intro
 


### PR DESCRIPTION
- Clicking on the Transloadit logo will navigate to transloadit.com (with some UTM parameters 😎) instead of just opening `logo.svg`.
- The logo now supports dark mode 🌚 

**Before:**

> <img width="941" alt="image" src="https://github.com/transloadit/node-sdk/assets/375537/ef43c529-44a5-42c8-ada2-6f85c1e903ad">

**After:**

> <img width="946" alt="image" src="https://github.com/transloadit/node-sdk/assets/375537/991fadab-479b-4f59-9f13-550e07c6ba69">
