### PR TITLE
Fix the test-all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test-unit": "vitest run --coverage ./test/unit",
     "test-integration": "vitest run ./test/integration",
     "tsd": "tsd",
-    "test-all": "npm run tsd && vitest run --coverage --forceExit",
+    "test-all": "npm run tsd && vitest run --coverage",
     "test": "npm run tsd && npm run test-unit",
     "fix:formatting": "prettier --write .",
     "lint:formatting": "prettier --check ."


### PR DESCRIPTION
Vitest doesn’t have a flag `--forceExit`. This was a remnant from when Jest was used.