### PR TITLE
Refactor to make code more TypeScript compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "got": "^11.8.1",
     "into-stream": "^6.0.0",
     "is-stream": "^2.0.0",
-    "lodash": "^4.17.20",
     "p-map": "^4.0.0",
     "tus-js-client": "^3.0.1",
     "uuid": "^8.3.2"

--- a/test/generate-coverage-badge.js
+++ b/test/generate-coverage-badge.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const fs = require('fs').promises
+const fs = require('fs/promises')
 const { makeBadge } = require('badge-maker')
 
 // eslint-disable-next-line import/newline-after-import

--- a/test/testserver.js
+++ b/test/testserver.js
@@ -1,6 +1,8 @@
 const http = require('http')
 const got = require('got')
-const debug = require('debug')('transloadit:testserver')
+const debug = require('debug')
+
+const log = debug('transloadit:testserver')
 
 const createTunnel = require('./tunnel')
 
@@ -13,7 +15,7 @@ async function createHttpServer(handler) {
     // Find a free port to use
     function tryListen() {
       server.listen(port, '127.0.0.1', () => {
-        debug(`server listening on port ${port}`)
+        log(`server listening on port ${port}`)
         resolve({ server, port })
       })
     }
@@ -45,7 +47,7 @@ async function createTestServer(onRequest) {
   let tunnel
 
   const handleHttpRequest = (req, res) => {
-    debug('HTTP request handler', req.method, req.url)
+    log('HTTP request handler', req.method, req.url)
 
     if (!initialized) {
       if (req.url !== expectedPath) throw new Error(`Unexpected path ${req.url}`)
@@ -62,17 +64,17 @@ async function createTestServer(onRequest) {
   async function close() {
     if (tunnel) await tunnel.close()
     await new Promise((resolve) => server.close(() => resolve()))
-    debug('closed tunnel')
+    log('closed tunnel')
   }
 
   try {
     tunnel = createTunnel({ cloudFlaredPath: process.env.CLOUDFLARED_PATH, port })
 
-    debug('waiting for tunnel to be created')
+    log('waiting for tunnel to be created')
     const tunnelPublicUrl = await tunnel.urlPromise
-    debug('tunnel created', tunnelPublicUrl)
+    log('tunnel created', tunnelPublicUrl)
 
-    debug('Waiting for tunnel to allow requests to pass through')
+    log('Waiting for tunnel to allow requests to pass through')
 
     // eslint-disable-next-line no-inner-declarations
     async function sendTunnelRequest() {
@@ -100,7 +102,7 @@ async function createTestServer(onRequest) {
       sendTunnelRequest(),
     ])
 
-    debug('Tunnel ready', tunnelPublicUrl)
+    log('Tunnel ready', tunnelPublicUrl)
 
     return {
       port,

--- a/test/unit/test-pagination-stream.test.js
+++ b/test/unit/test-pagination-stream.test.js
@@ -1,5 +1,4 @@
 const { Writable } = require('stream')
-const _ = require('lodash')
 
 const PaginationStream = require('../../src/PaginationStream')
 
@@ -27,10 +26,7 @@ describe('PaginationStream', () => {
     await new Promise((resolve) => {
       stream.pipe(
         toArray((array) => {
-          const expected = _.flatten(
-            Array.from(pages).map(({ items }) => items),
-            true
-          )
+          const expected = pages.flatMap(({ items }) => items)
 
           expect(array).toEqual(expected)
           resolve()
@@ -56,10 +52,7 @@ describe('PaginationStream', () => {
     await new Promise((resolve) => {
       stream.pipe(
         toArray((array) => {
-          const expected = _.flatten(
-            Array.from(pages).map(({ items }) => items),
-            true
-          )
+          const expected = pages.flatMap(({ items }) => items)
 
           expect(array).toEqual(expected)
           resolve()

--- a/test/unit/test-transloadit-client.test.js
+++ b/test/unit/test-transloadit-client.test.js
@@ -1,10 +1,10 @@
-const { Readable: ReadableStream } = require('stream')
+const stream = require('stream')
 const FormData = require('form-data')
 const got = require('got')
 
 const tus = require('../../src/tus')
 const Transloadit = require('../../src/Transloadit')
-const packageVersion = require('../../package.json').version
+const pkg = require('../../package.json')
 
 const mockedExpiresDate = '2021-01-06T21:11:07.883Z'
 const mockGetExpiresDate = (client) =>
@@ -108,8 +108,8 @@ describe('Transloadit', () => {
     it('should append all required fields to the request form', () => {
       const client = new Transloadit({ authKey: 'foo_key', authSecret: 'foo_secret' })
 
-      const stream1 = new ReadableStream()
-      const stream2 = new ReadableStream()
+      const stream1 = new stream.Readable()
+      const stream2 = new stream.Readable()
 
       const streamsMap = {
         stream1: { stream: stream1 },
@@ -280,7 +280,7 @@ describe('Transloadit', () => {
 
       expect(get).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ headers: { 'Transloadit-Client': `node-sdk:${packageVersion}` } })
+        expect.objectContaining({ headers: { 'Transloadit-Client': `node-sdk:${pkg.version}` } })
       )
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3848,13 +3848,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
 "log-symbols@npm:^4.0.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -5761,7 +5754,6 @@ __metadata:
     got: "npm:^11.8.1"
     into-stream: "npm:^6.0.0"
     is-stream: "npm:^2.0.0"
-    lodash: "npm:^4.17.20"
     nock: "npm:^13.0.5"
     npm-run-all: "npm:^4.1.5"
     p-map: "npm:^4.0.0"


### PR DESCRIPTION
This change contains some refactors, mostly to make the code better compatible with TypeScript.

All `require()` calls were changed to the form
`const identifier = require('specifier')`. This is compatible with TypeScript’s `verbatimModuleSyntax` option, which is strongly recommended in order to produce valid library types.

All uses of `lodash` were changed to native JavaScript implementations. The `lodash` dependency was removed.

Static class assignments were changed to static class property syntax.

`util.promisify` usage was replaced with Node.js promise APIs.