### PR TITLE
Add cloudflared* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+cloudflared*
 credentials.js
 sample.js
 


### PR DESCRIPTION
The file `cloudflared-linux-amd64` is used in integration tests. It’s downloaded during CI runs and is not supposed to be committed.