### PR TITLE
Replace the uuid module with crypto.randomUUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Tim Koschuetzki <tim@transloadit.com>",
   "packageManager": "yarn@4.0.1",
   "engines": {
-    "node": ">= 14.16"
+    "node": ">= 14.17"
   },
   "dependencies": {
     "debug": "^4.3.1",
@@ -22,8 +22,7 @@
     "into-stream": "^6.0.0",
     "is-stream": "^2.0.0",
     "p-map": "^4.0.0",
-    "tus-js-client": "^3.0.1",
-    "uuid": "^8.3.2"
+    "tus-js-client": "^3.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -1,6 +1,6 @@
+const crypto = require('crypto')
 const got = require('got')
 const FormData = require('form-data')
-const crypto = require('crypto')
 const fs = require('fs')
 const fsPromises = require('fs/promises')
 const debug = require('debug')
@@ -8,7 +8,6 @@ const intoStream = require('into-stream')
 const isStream = require('is-stream')
 const assert = require('assert')
 const pMap = require('p-map')
-const uuid = require('uuid')
 
 const InconsistentResponseError = require('./InconsistentResponseError')
 const PaginationStream = require('./PaginationStream')
@@ -167,7 +166,7 @@ class TransloaditClient {
     if (assemblyId != null) {
       effectiveAssemblyId = assemblyId
     } else {
-      effectiveAssemblyId = uuid.v4().replace(/-/g, '')
+      effectiveAssemblyId = crypto.randomUUID().replace(/-/g, '')
     }
     const urlSuffix = `/assemblies/${effectiveAssemblyId}`
 

--- a/test/integration/live-api.test.js
+++ b/test/integration/live-api.test.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto')
 const querystring = require('querystring')
 const temp = require('temp')
 const fs = require('fs')
@@ -5,7 +6,6 @@ const nodePath = require('path')
 const nodeStream = require('stream/promises')
 const got = require('got')
 const intoStream = require('into-stream')
-const uuid = require('uuid')
 const debug = require('debug')
 
 const log = debug('transloadit:live-api')
@@ -129,7 +129,7 @@ afterAll(async () => {
 })
 
 async function createVirtualTestServer(handler) {
-  const id = uuid.v4()
+  const id = crypto.randomUUID()
   log('Adding virtual server handler', id)
   const url = `${testServer.url}/${id}`
   handlers.set(id, handler)
@@ -296,7 +296,7 @@ describe('API integration', { timeout: 30000 }, () => {
     it('should allow setting an explicit assemblyId on createAssembly', async () => {
       const client = createClient()
 
-      const assemblyId = uuid.v4().replace(/-/g, '')
+      const assemblyId = crypto.randomUUID().replace(/-/g, '')
       const params = {
         assemblyId,
         waitForCompletion: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5762,7 +5762,6 @@ __metadata:
     temp: "npm:^0.9.1"
     tsd: "npm:^0.25.0"
     tus-js-client: "npm:^3.0.1"
-    uuid: "npm:^8.3.2"
     vitest: "npm:^2.0.5"
   languageName: unknown
   linkType: soft
@@ -6000,15 +5999,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This raises the minimal Node.js version from 14.16 to 14.17. This should be fine, considering Node.js 16 is already EOL, and 14.17 isn’t even the latest in the Node.js 14 release line.

The global crypto would require a much newer version, hence the crypto module is imported.