### PR TITLE
Define custom error types

### DIFF
--- a/src/InconsistentResponseError.js
+++ b/src/InconsistentResponseError.js
@@ -1,8 +1,5 @@
 class InconsistentResponseError extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'InconsistentResponseError'
-  }
+  name = 'InconsistentResponseError'
 }
 
 module.exports = InconsistentResponseError

--- a/src/PollingTimeoutError.js
+++ b/src/PollingTimeoutError.js
@@ -1,0 +1,7 @@
+class PollingTimeoutError extends Error {
+  name = 'PollingTimeoutError'
+
+  code = 'POLLING_TIMED_OUT'
+}
+
+module.exports = PollingTimeoutError

--- a/src/TransloaditError.js
+++ b/src/TransloaditError.js
@@ -1,0 +1,10 @@
+class TransloaditError extends Error {
+  name = 'TransloaditError'
+
+  constructor(message, body) {
+    super(message)
+    this.response = { body }
+  }
+}
+
+module.exports = TransloaditError


### PR DESCRIPTION
We currently decorate plain Error objects. TypeScript doesn’t like this. We better use custom error types.