### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,20 @@ jobs:
       - run: corepack yarn
       - run: corepack yarn eslint .
 
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: corepack yarn
+      - run: corepack yarn pack
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: '*.tgz'
+
   prettier:
     runs-on: ubuntu-latest
     steps:
@@ -52,3 +66,25 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: corepack yarn
       - run: corepack yarn vitest run --coverage ./test/unit
+
+  release:
+    runs-on: ubuntu-latest
+    needs:
+      - eslint
+      - pack
+      - prettier
+      - tsd
+      - vitest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - uses: actions/download-artifact@v4
+        with: { name: package }
+      - run: npm publish *.tgz --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `pack` job creates the npm package for every commit. The `release` job publishes the package for git tags.

To make this work, we need to define the `NPM_TOKEN` GitHub secret.