### PR TITLE
Remove support for Node.js 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Tim Koschuetzki <tim@transloadit.com>",
   "packageManager": "yarn@4.0.1",
   "engines": {
-    "node": ">= 14.17"
+    "node": ">= 18"
   },
   "dependencies": {
     "debug": "^4.3.1",


### PR DESCRIPTION
Node.js 18 is currently the oldest version that’s still supported.