### PR TITLE
Remove support createAssembly callback check

### DIFF
--- a/src/Transloadit.ts
+++ b/src/Transloadit.ts
@@ -155,14 +155,7 @@ export class Transloadit {
    *
    * @param opts assembly options
    */
-  createAssembly(opts: CreateAssemblyOptions = {}, arg2?: void): CreateAssemblyPromise {
-    // Warn users of old callback API
-    if (typeof arg2 === 'function') {
-      throw new TypeError(
-        'You are trying to send a function as the second argument. This is no longer valid in this version. Please see github README for usage.'
-      )
-    }
-
+  createAssembly(opts: CreateAssemblyOptions = {}): CreateAssemblyPromise {
     const {
       params = {},
       waitForCompletion = false,

--- a/test/unit/test-transloadit-client.test.ts
+++ b/test/unit/test-transloadit-client.test.ts
@@ -287,18 +287,6 @@ describe('Transloadit', () => {
     )
   })
 
-  it('should crash if attempt to use callback', async () => {
-    const client = new Transloadit({ authKey: 'foo_key', authSecret: 'foo_secret' })
-    const cb = () => {}
-    expect(() =>
-      client.createAssembly(
-        {},
-        // @ts-expect-error This tests bad input
-        cb
-      )
-    ).toThrow(TypeError)
-  })
-
   describe('_calcSignature', () => {
     it('should calculate the signature properly', () => {
       const client = new Transloadit({ authKey: 'foo_key', authSecret: 'foo_secret' })


### PR DESCRIPTION
Users have had time to migrate. Also the type definitions don’t allow it.