### PR TITLE
Fix the examples

### DIFF
--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -1,5 +1,7 @@
 module.exports = {
   rules: {
     'no-console': 0,
+    'import/no-extraneous-dependencies': 0,
+    'import/no-unresolved': 0,
   },
 }

--- a/examples/convert_to_webp.js
+++ b/examples/convert_to_webp.js
@@ -1,14 +1,16 @@
 // Run this file as:
 //
-//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node examples/convert_to_webp.js ./fixtures/berkley.jpg
+//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node examples/convert_to_webp.js ./examples/fixtures/berkley.jpg
 //
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 const filePath = process.argv[2]

--- a/examples/credentials.js
+++ b/examples/credentials.js
@@ -3,16 +3,18 @@
 //
 //   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node template_api.js
 //
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
-  // authKey   : process.env.API2_SYSTEMTEST_AUTH_KEY,
-  // authSecret: process.env.API2_SYSTEMTEST_SECRET_KEY,
-  // endpoint  : 'https://api2-vbox.transloadit.com',
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
+  // authKey: /** @type {string} */ (process.env.API2_SYSTEMTEST_AUTH_KEY),
+  // authSecret: /** @type {string} */ (process.env.API2_SYSTEMTEST_SECRET_KEY),
+  // endpoint: /** @type {string} */ ('https://api2-vbox.transloadit.com'),
 })
 
 const firstName = 'myProductionS3'
@@ -51,9 +53,8 @@ const credentialParams = {
     }
 
     console.log(`==> createTemplateCredential`)
-    const createTemplateCredentialResult = await transloadit.createTemplateCredential(
-      credentialParams
-    )
+    const createTemplateCredentialResult =
+      await transloadit.createTemplateCredential(credentialParams)
     console.log('TemplateCredential created successfully:', createTemplateCredentialResult)
     // ^-- with   Templates, there is `ok`, `message`, `id`, `content`, `name`, `require_signature_auth`. Same is true for: created, updated, fetched
     //     with Credentials, there is `ok`, `message`, `credentials` <-- and a single object nested directly under it, which is unexpected with that plural imho. Same is true for created, updated, fetched

--- a/examples/face_detect_download.js
+++ b/examples/face_detect_download.js
@@ -1,6 +1,10 @@
 // Run this file as:
 //
-//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node examples/face_detect_download.js ./fixtures/berkley.jpg
+//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node examples/face_detect_download.js ./examples/fixtures/berkley.jpg
+//
+// You may need to build the project first using:
+//
+//   yarn prepack
 //
 // This example will take an image and find a face and crop out the face.
 // Then it will download the result as a file in the current directory
@@ -8,14 +12,11 @@
 
 const got = require('got')
 const { createWriteStream } = require('fs')
-
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 const filePath = process.argv[2]
@@ -46,7 +47,7 @@ const filePath = process.argv[2]
     // Now save the file
     const outPath = './output-face.jpg'
     const stream = createWriteStream(outPath)
-    await got.stream(status.results.facesDetected[0].url).pipe(stream)
+    await got.default.stream(status.results.facesDetected[0].url).pipe(stream)
     console.log('Your cropped face has been saved to', outPath)
   } catch (err) {
     console.error('createAssembly failed', err)

--- a/examples/fetch_costs_of_all_assemblies_in_timeframe.js
+++ b/examples/fetch_costs_of_all_assemblies_in_timeframe.js
@@ -2,12 +2,12 @@
 //
 //   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node fetch_costs_of_all_assemblies_in_timeframe.js
 //
-// make sure to "npm install p-map" for this demo
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
 const pMap = require('p-map')
-
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+const { Transloadit } = require('transloadit')
 
 const fromdate = '2020-12-31 15:30:00'
 const todate = '2020-12-31 15:30:01'
@@ -21,8 +21,8 @@ const todate = '2020-12-31 15:30:01'
     }
 
     const transloadit = new Transloadit({
-      authKey: process.env.TRANSLOADIT_KEY,
-      authSecret: process.env.TRANSLOADIT_SECRET,
+      authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+      authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
     })
 
     let totalBytes = 0
@@ -38,7 +38,7 @@ const todate = '2020-12-31 15:30:01'
         items,
         // eslint-disable-next-line no-loop-func
         async (assembly) => {
-          const assemblyFull = await transloadit.getAssembly(assembly.id)
+          const assemblyFull = await transloadit.getAssembly(/** @type {string} */ (assembly.id))
           // console.log(assemblyFull.assembly_id)
 
           const { bytes_usage: bytesUsage } = assemblyFull

--- a/examples/rasterize_svg_to_png.js
+++ b/examples/rasterize_svg_to_png.js
@@ -1,14 +1,16 @@
 // Run this file as:
 //
-//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node rasterize_svg_to_png.js ./fixtures/circle.svg
+//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node rasterize_svg_to_png.js ./examples/fixtures/circle.svg
 //
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 const filePath = process.argv[2]

--- a/examples/resize_an_image.js
+++ b/examples/resize_an_image.js
@@ -1,14 +1,16 @@
 // Run this file as:
 //
-//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node resize_an_image.js ./fixtures/berkley.jpg
+//   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node resize_an_image.js ./examples/fixtures/berkley.jpg
 //
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 const filePath = process.argv[2]

--- a/examples/retry.js
+++ b/examples/retry.js
@@ -4,17 +4,16 @@
 //
 //   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node retry.js
 //
-
-// eslint-disable-next-line import/no-extraneous-dependencies
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
 const pRetry = require('p-retry')
-
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+const { Transloadit, TransloaditError } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 async function run() {
@@ -23,7 +22,7 @@ async function run() {
     const { items } = await transloadit.listTemplates({ sort: 'created', order: 'asc' })
     return items
   } catch (err) {
-    if (err.transloaditErrorCode === 'INVALID_SIGNATURE') {
+    if (err instanceof TransloaditError && err.transloaditErrorCode === 'INVALID_SIGNATURE') {
       // This is an unrecoverable error, abort retry
       throw new pRetry.AbortError('INVALID_SIGNATURE')
     }

--- a/examples/template_api.js
+++ b/examples/template_api.js
@@ -2,13 +2,15 @@
 //
 //   env TRANSLOADIT_KEY=xxx TRANSLOADIT_SECRET=yyy node template_api.js
 //
-// You'll likely just want to `require('transloadit')`, but we're requiring the local
-// variant here for easier testing:
-const Transloadit = require('../src/Transloadit')
+// You may need to build the project first using:
+//
+//   yarn prepack
+//
+const { Transloadit } = require('transloadit')
 
 const transloadit = new Transloadit({
-  authKey: process.env.TRANSLOADIT_KEY,
-  authSecret: process.env.TRANSLOADIT_SECRET,
+  authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
+  authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
 })
 
 const template = {

--- a/src/Transloadit.ts
+++ b/src/Transloadit.ts
@@ -28,7 +28,7 @@ export {
   MaxRedirectsError,
   TimeoutError,
 } from 'got'
-export { InconsistentResponseError }
+export { InconsistentResponseError, TransloaditError }
 
 const log = debug('transloadit')
 const logWarn = debug('transloadit:warn')

--- a/test/generate-coverage-badge.js
+++ b/test/generate-coverage-badge.js
@@ -6,7 +6,7 @@ const { makeBadge } = require('badge-maker')
 // eslint-disable-next-line import/newline-after-import
 ;(async () => {
   try {
-    const json = JSON.parse(await fs.readFile(process.argv[2]), 'utf-8')
+    const json = JSON.parse(await fs.readFile(process.argv[2], 'utf-8'))
 
     // We only care about "statements"
     const coveragePercent = `${json.total.statements.pct}%`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
-  "exclude": ["src"],
+  "exclude": ["dist", "src"],
   "references": [{ "path": "./tsconfig.build.json" }],
   "compilerOptions": {
+    "checkJs": true,
     "isolatedModules": true,
     "module": "node16",
     "noImplicitOverride": true,


### PR DESCRIPTION
Since the migration to TypeScript, examples had to be adjusted. The SDK now uses named exports. Also the SDK needs to be built before examples can be run. This is now displayed on top of the example instructions.

Since the SDK now used package exports, the examples can now import the package using its name instead of relative imports.

Some ESLint warnings have been disabled for the examples.

Incorrect paths to example fixtures have been fixed.

The examples are now type-checked using JSDoc based type annotations.

Closes #204