### PR TITLE
Remove commented constructor keys in example

### DIFF
--- a/examples/credentials.js
+++ b/examples/credentials.js
@@ -12,9 +12,6 @@ const { Transloadit } = require('transloadit')
 const transloadit = new Transloadit({
   authKey: /** @type {string} */ (process.env.TRANSLOADIT_KEY),
   authSecret: /** @type {string} */ (process.env.TRANSLOADIT_SECRET),
-  // authKey: /** @type {string} */ (process.env.API2_SYSTEMTEST_AUTH_KEY),
-  // authSecret: /** @type {string} */ (process.env.API2_SYSTEMTEST_SECRET_KEY),
-  // endpoint: /** @type {string} */ ('https://api2-vbox.transloadit.com'),
 })
 
 const firstName = 'myProductionS3'


### PR DESCRIPTION
It’s not really useful information in the example.

See https://github.com/transloadit/node-sdk/pull/205#discussion_r1875423337