### PR TITLE
Fix monster error stack

### DIFF
--- a/test/integration/live-api.test.ts
+++ b/test/integration/live-api.test.ts
@@ -12,6 +12,7 @@ import debug = require('debug')
 
 import { CreateAssemblyOptions, Transloadit, UploadProgress } from '../../src/Transloadit'
 import { createTestServer, TestServer } from '../testserver'
+import { createProxy } from '../util'
 
 const log = debug('transloadit:live-api')
 
@@ -54,7 +55,7 @@ function createClient(opts = {}) {
     ],
   }
 
-  return new Transloadit({ authKey, authSecret, gotRetry, ...opts })
+  return createProxy(new Transloadit({ authKey, authSecret, gotRetry, ...opts }))
 }
 
 function createAssembly(client: Transloadit, params: CreateAssemblyOptions) {

--- a/test/unit/mock-http.test.ts
+++ b/test/unit/mock-http.test.ts
@@ -10,7 +10,9 @@ import {
 import { createProxy } from '../util'
 
 const getLocalClient = (opts?: Omit<Transloadit.Options, 'authKey' | 'authSecret' | 'endpoint'>) =>
-  createProxy(new Transloadit({ authKey: '', authSecret: '', endpoint: 'http://localhost', ...opts }))
+  createProxy(
+    new Transloadit({ authKey: '', authSecret: '', endpoint: 'http://localhost', ...opts })
+  )
 
 const createAssemblyRegex = /\/assemblies\/[0-9a-f]{32}/
 

--- a/test/unit/mock-http.test.ts
+++ b/test/unit/mock-http.test.ts
@@ -133,8 +133,8 @@ describe('Mocked API tests', () => {
       expect.stringMatching(
         `    at createAssemblyAndUpload \\(.+\\/src\\/Transloadit\\.ts:\\d+:\\d+\\)`
       ),
-      expect.stringMatching(`    at .+\\/test\\/util\\.ts:\\d+:\\d+`),
       expect.stringMatching(`    at .+\\/test\\/unit\\/mock-http\\.test\\.ts:\\d+:\\d+`),
+      expect.stringMatching(`    at .+`),
       expect.stringMatching(`    at .+`),
       expect.stringMatching(`    at .+`),
       expect.stringMatching(`    at .+`),

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,14 +1,14 @@
-import { HTTPError, Transloadit } from '../src/Transloadit';
+import { HTTPError, Transloadit } from '../src/Transloadit'
 
 export const createProxy = (transloaditInstance: Transloadit) => {
   return new Proxy(transloaditInstance, {
     get(target, propKey) {
       // @ts-expect-error I dunno how to type
-      const origMethod = target[propKey];
+      const origMethod = target[propKey]
       if (typeof origMethod === 'function') {
         return async function (...args: any) {
           try {
-            return await origMethod.apply(target, args);
+            return await origMethod.apply(target, args)
           } catch (err) {
             if (err instanceof Error && 'cause' in err && err.cause instanceof HTTPError) {
               if (err.cause.request) {
@@ -32,9 +32,9 @@ export const createProxy = (transloaditInstance: Transloadit) => {
             }
             throw err
           }
-        };
+        }
       }
-      return origMethod;
-    }
-  });
-};
+      return origMethod
+    },
+  })
+}

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,40 @@
+import { HTTPError, Transloadit } from '../src/Transloadit';
+
+export const createProxy = (transloaditInstance: Transloadit) => {
+  return new Proxy(transloaditInstance, {
+    get(target, propKey) {
+      // @ts-expect-error I dunno how to type
+      const origMethod = target[propKey];
+      if (typeof origMethod === 'function') {
+        return async function (...args: any) {
+          try {
+            return await origMethod.apply(target, args);
+          } catch (err) {
+            if (err instanceof Error && 'cause' in err && err.cause instanceof HTTPError) {
+              if (err.cause.request) {
+                Object.defineProperty(err.cause.request, 'toJSON', {
+                  value: () => undefined,
+                  enumerable: false,
+                })
+                Object.defineProperty(err.cause.response, 'toJSON', {
+                  value: () => undefined,
+                  enumerable: false,
+                })
+                Object.defineProperty(err.cause.options, 'toJSON', {
+                  value: () => undefined,
+                  enumerable: false,
+                })
+                Object.defineProperty(err.cause.timings, 'toJSON', {
+                  value: () => undefined,
+                  enumerable: false,
+                })
+              }
+            }
+            throw err
+          }
+        };
+      }
+      return origMethod;
+    }
+  });
+};

--- a/test/util.ts
+++ b/test/util.ts
@@ -12,7 +12,7 @@ export const createProxy = (transloaditInstance: Transloadit) => {
           if (!(result && 'then' in result)) {
             return result
           }
-        
+
           // @ts-expect-error any
           return result.catch((err) => {
             if (err instanceof Error && 'cause' in err && err.cause instanceof HTTPError) {


### PR DESCRIPTION
This was a tricky one. The problem is a combination of
1. the fact that `got` includes a lot of metadata properties on their errors, like `request`, `response`, `timings` etc,
2. when `vitest` logs an error, they take **all** of the properties on the error object and deeply serialize it, and there's no easy way to disable this behavior.

Vitest issues:
- https://github.com/vitest-dev/vitest/issues/5487
- https://github.com/vitest-dev/vitest/issues/2976

Example:
```
Caused by: HTTPError: Response code 429 (Too Many Requests)
 ❯ Request.<anonymous> node_modules/got/dist/source/as-promise/index.js:118:42

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { code: 'ERR_NON_2XX_3XX_RESPONSE', request: { _readableState: { state: 322582, highWaterMark: +0, buffer: { head: null, tail: null, length: +0, constructor: 'Function<BufferList>', push: 'Function<push>', unshift: 'Function<unshift>', shift: 'Function<shift>', clear: 'Function<clear>', join: 'Function<join>', concat: 'Function<concat>', consume: 'Function<consume>', first: 'Function<first>', _getString: 'Function<_getString>', _getBuffer: 'Function<_getBuffer>' }, length: +0, pipes: [], flowing: null, errored: { stack: 'HTTPError: Response code 429 (Too Many Requests)\n    at Request.<anonymous> (/home/runner/work/node-sdk/node-sdk/node_modules/got/dist/source/as-promise/index.js:118:42)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)', message: 'Response code 429 (Too Many Requests)', name: 'Caused by: HTTPError', code: 'ERR_NON_2XX_3XX_RESPONSE', request: [Circular], response: { _readableState: { state: 325910, highWaterMark: 16384, buffer: { head: null, tail: null, length: +0, constructor: 'Function<BufferList>', push: 'Function<push>', unshift: 'Function<unshift>', shift: 'Function<shift>', clear: 'Function<clear>', join: 'Function<join>', concat: 'Function<concat>', consume: 'Function<consume>', first: 'Function<first>', _getString: 'Function<_getString>', _getBuffer: 'Function<_getBuffer>' }, length: +0, pipes: [], flowing: false, errored: null, defaultEncoding: 'utf8', awaitDrainWriters: null, decoder: null, encoding: null, constructor: 'Function<ReadableState>', objectMode: false, ended: true, endEmitted: true, reading: false, constructed: true, sync: false, needReadable: false, emittedReadable: false, readableListening: true, resumeScheduled: false, errorEmitted: false, emitClose: true, autoDestroy: true, destroyed: true, closed: true, closeEmitted: true, multiAwaitDrain: false, readingMore: false, dataEmitted: true, pipesCount: +0, paused: true }, _events: { end: 'Function<responseOnEnd>', aborted: [ 'Function<bound onceWrapper>', 'Function<bound onceWrapper>' ], error: 'Function<bound onceWrapper>', readable: 'Function<anonymous>' }, _eventsCount: 4, _maxListeners: undefined, socket: { _tlsOptions: { allowHalfOpen: undefined, pipe: false, secureContext: { context: { init: 'Function<init>', setKey: 'Function<setKey>', setCert: 'Function<setCert>', addCACert: 'Function<addCACert>', addCRL: 'Function<addCRL>', addRootCerts: 'Function<addRootCerts>', setCipherSuites: 'Function<setCipherSuites>', setCiphers: 'Function<setCiphers>', setSigalgs: 'Function<setSigalgs>', setECDHCurve: 'Function<setECDHCurve>', setDHParam: 'Function<setDHParam>', setMaxProto: 'Function<setMaxProto>', setMinProto: 'Function<setMinProto>', getMaxProto: 'Function<getMaxProto>', getMinProto: 'Function<getMinProto>', setOptions: 'Function<setOptions>', setSessionIdContext: 'Function<setSessionIdContext>', setSessionTimeout: 'Function<setSessionTimeout>', close: 'Function<close>', loadPKCS12: 'Function<loadPKCS12>', setTicketKeys: 'Function<setTicketKeys>', enableTicketKeyCallback: 'Function<enableTicketKeyCallback>', getTicketKeys: 'Function<getTicketKeys>', getCertificate: 'Function<getCertificate>', getIssuer: 'Function<getIssuer>', setEngineKey: 'Function<setEngineKey>', setClientCertEngine: 'Function<setClientCertEngine>', _external: {}, constructor: 'Function<SecureContext>' }, constructor: 'Function<SecureContext>' }, isServer: false, requestCert: true, rejectUnauthorized: true, session: { type: 'Buffer', data: [ 48, 130, 5, 203, 2, 1, 1, 2, 2, 3, 4, 4, 2, 19, 2,

...and hundreds of more kB
```

Because imo this is mostly a problem with vitest, and from the previous 2 issues it doesn't seem like the vitest team wants to change this behaviour, the workaround is to wrap the Transloadit object (when running tests) in a Proxy that will catch-rethrow all errors with a toJSON on all the properties that we don't want to expose in the vitest error serialization. this makes sure Transloadit error API doesn't change, and people can still access properties like `err.response.body`.

I think in a future major of our SDK we should probably make our own opaque error abstraction that wraps all got (http request) specific errors, instead of passing them through (which we do now). This will also probably avoid this `vitest` problem, unless we decide to still expose stuff like HTTP response bodies in our errors.

kind of related: https://github.com/sindresorhus/got/issues/1126