### PR TITLE
Fix deep types error

### DIFF
--- a/src/alphalib/types/template.ts
+++ b/src/alphalib/types/template.ts
@@ -64,6 +64,7 @@ export const assemblyInstructionsSchema = z.object({
     .describe(
       'Set this to true to reduce the response from an Assembly POST request to only the necessary fields. This prevents any potentially confidential information being leaked to the end user who is making the Assembly request. A successful Assembly will only include the ok and assembly_id fields. An erroneous Assembly will only include the error, http_code, message and assembly_id fields. The full Assembly Status will then still be sent to the notify_url if one was specified.',
     ),
+  // This is done to avoid heavy inference cost
   steps: optionalStepsSchema as typeof optionalStepsSchema,
   template_id: z.string().optional().describe('The Template ID to use'),
 })

--- a/src/alphalib/types/template.ts
+++ b/src/alphalib/types/template.ts
@@ -15,6 +15,7 @@ export type StepInput = z.input<typeof stepSchema>
 export type StepInputWithUse = StepInput & RobotUse
 export type Steps = z.infer<typeof stepsSchema>
 export type StepsInput = z.input<typeof stepsSchema>
+const optionalStepsSchema = stepsSchema.optional()
 
 export const stepSchemaWithHiddenFields = z
   .object({
@@ -63,7 +64,7 @@ export const assemblyInstructionsSchema = z.object({
     .describe(
       'Set this to true to reduce the response from an Assembly POST request to only the necessary fields. This prevents any potentially confidential information being leaked to the end user who is making the Assembly request. A successful Assembly will only include the ok and assembly_id fields. An erroneous Assembly will only include the error, http_code, message and assembly_id fields. The full Assembly Status will then still be sent to the notify_url if one was specified.',
     ),
-  steps: stepsSchema.optional(),
+  steps: optionalStepsSchema as typeof optionalStepsSchema,
   template_id: z.string().optional().describe('The Template ID to use'),
 })
 


### PR DESCRIPTION
One of the big features of TypeScript, is that it can infer types based on context. This is powerful, but it comes at a cost. Determining types based on inference consumes much more resources than using a type annotation. This is an important reason to add explicit type annotations.

We heavily rely on Zod though. Zod is powerful, but it heavily relies on inference. This means that by using Zod, we sacrifice type checking performance. Zod 4 will supposedly be more performant. This is great, but by definition it can’t be as performant as regular types.

When the types become really complex, TypeScript may error on this. An explicit type annotation in the right spot fixes this. This PR uses this to resolve the type error. I can’t explain why this surfaced here, but not in our internal repos these schemas originate from.