### PR TITLE
add validateResponses option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The `options` object can contain the following keys:
 - `maxRetries` (default `5`) - see [Rate limiting & auto retry](#rate-limiting--auto-retry)
 - `gotRetry` (default `0`) - see [Rate limiting & auto retry](#rate-limiting--auto-retry)
 - `timeout` (default `60000`: 1 minute) - the timeout (in milliseconds) for all requests (except `createAssembly`)
+- `validateResponses` (default `true`)
 
 ### Assemblies
 
@@ -456,6 +457,10 @@ All functions of the client automatically obey all rate limiting imposed by Tran
 Because we use [got](https://github.com/sindresorhus/got) under the hood, you can pass a `gotRetry` constructor option which is passed on to `got`. This offers great flexibility for handling retries on network errors and HTTP status codes with auto back-off. See [`got` `retry` object documentation](https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md).
 
 **Note that the above `maxRetries` option does not affect the `gotRetry` logic.**
+
+#### Validate API responses (`validateResponses`, default `true`)
+
+As we have ported the JavaScript SDK to TypeScript in v4, we are now also validating API responses using `zod` schemas. Having schema validation enabled (`true`), guarantees that the data returned by the SDK adheres to the TypeScript types of this SDK. However we are still working on improving the schemas and they are not yet 100% complete. This means that if you hit a bug in the schemas, a `zod` schema validation error will be thrown. If you encounter such an error, please report it and we will fix it as soon as possible. If you set this option to `false`, schema validation will be disabled, and you won't get any such errors, however the TypeScript types will not protect you should such a bug be encountered.
 
 #### Custom retry logic
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The `options` object can contain the following keys:
 - `maxRetries` (default `5`) - see [Rate limiting & auto retry](#rate-limiting--auto-retry)
 - `gotRetry` (default `0`) - see [Rate limiting & auto retry](#rate-limiting--auto-retry)
 - `timeout` (default `60000`: 1 minute) - the timeout (in milliseconds) for all requests (except `createAssembly`)
-- `validateResponses` (default `true`)
+- `validateResponses` (default `false`)
 
 ### Assemblies
 
@@ -458,7 +458,7 @@ Because we use [got](https://github.com/sindresorhus/got) under the hood, you ca
 
 **Note that the above `maxRetries` option does not affect the `gotRetry` logic.**
 
-#### Validate API responses (`validateResponses`, default `true`)
+#### Validate API responses (`validateResponses`, default `false`)
 
 As we have ported the JavaScript SDK to TypeScript in v4, we are now also validating API responses using `zod` schemas. Having schema validation enabled (`true`), guarantees that the data returned by the SDK adheres to the TypeScript types of this SDK. However we are still working on improving the schemas and they are not yet 100% complete. This means that if you hit a bug in the schemas, a `zod` schema validation error will be thrown. If you encounter such an error, please report it and we will fix it as soon as possible. If you set this option to `false`, schema validation will be disabled, and you won't get any such errors, however the TypeScript types will not protect you should such a bug be encountered.
 

--- a/src/Transloadit.ts
+++ b/src/Transloadit.ts
@@ -185,7 +185,7 @@ export class Transloadit {
 
   private _lastUsedAssemblyUrl = ''
 
-  private _validateResponses = true
+  private _validateResponses = false
 
   constructor(opts: Options) {
     if (opts?.authKey == null) {

--- a/src/Transloadit.ts
+++ b/src/Transloadit.ts
@@ -167,6 +167,7 @@ export interface Options {
   maxRetries?: number
   timeout?: number
   gotRetry?: Partial<RetryOptions>
+  validateResponses?: boolean
 }
 
 export class Transloadit {
@@ -183,6 +184,8 @@ export class Transloadit {
   private _gotRetry: Partial<RetryOptions>
 
   private _lastUsedAssemblyUrl = ''
+
+  private _validateResponses = true
 
   constructor(opts: Options) {
     if (opts?.authKey == null) {
@@ -205,6 +208,8 @@ export class Transloadit {
 
     // Passed on to got https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md
     this._gotRetry = opts.gotRetry != null ? opts.gotRetry : { limit: 0 }
+
+    if (opts.validateResponses != null) this._validateResponses = opts.validateResponses
   }
 
   getLastUsedAssemblyUrl(): string {
@@ -383,6 +388,22 @@ export class Transloadit {
     }
   }
 
+  maybeThrowInconsistentResponseError(message: string) {
+    const err = new InconsistentResponseError(message)
+
+    // @TODO, once our schemas have matured, we should remove the option and always throw the error here.
+    // But as it stands, schemas are new, and we can't easily update all customer's node-sdks,
+    // so there will be a long tail of throws if we enable this now.
+    if (this._validateResponses) {
+      throw err
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `---\nPlease report this error to Transloadit (support@transloadit.com). We are working on better schemas for our API and this looks like something we do not cover yet: \n\n${err}\nThank you in advance!\n---\n`
+    )
+  }
+
   /**
    * Cancel the assembly
    *
@@ -397,23 +418,15 @@ export class Transloadit {
     })
 
     const parsedResult = zodParseWithContext(assemblyStatusSchema, rawResult)
+
     if (!parsedResult.success) {
-      const err = new InconsistentResponseError(
+      this.maybeThrowInconsistentResponseError(
         `The API responded with data that does not match the expected schema while cancelling Assembly: ${assemblyId}.\n${parsedResult.humanReadable}`
       )
-      // eslint-disable-next-line no-console
-      console.error(
-        `---\nPlease report this error to Transloadit (support@transloadit.com). We are working on better schemas for our API and this looks like something we do not cover yet: \n\n${err}\nThank you in advance!\n---\n`
-      )
-      // @TODO, once our schemas have matured, we should throw the error here.
-      // But as it stands, schemas are new, and we can't easily update all customer's node-sdks,
-      // so there will be a long tail of throws if we enable this now.
-      checkAssemblyUrls(rawResult as AssemblyStatus)
-      return rawResult as AssemblyStatus
     }
 
-    checkAssemblyUrls(parsedResult.safe)
-    return parsedResult.safe
+    checkAssemblyUrls(rawResult as AssemblyStatus)
+    return rawResult as AssemblyStatus
   }
 
   /**
@@ -485,24 +498,13 @@ export class Transloadit {
     const parsedResult = zodParseWithContext(assemblyIndexSchema, rawResponse.items)
 
     if (!parsedResult.success) {
-      const err = new InconsistentResponseError(
+      this.maybeThrowInconsistentResponseError(
         `API response for listAssemblies contained items that do not match the expected schema.\n${parsedResult.humanReadable}`
       )
-      // eslint-disable-next-line no-console
-      console.error(
-        `---\nPlease report this error to Transloadit (support@transloadit.com). We are working on better schemas for our API and this looks like something we do not cover yet: \n\n${err}\nThank you in advance!\n---\n`
-      )
-      return {
-        // @TODO, once our schemas have matured, we should throw the error here.
-        // But as it stands, schemas are new, and we can't easily update all customer's node-sdks,
-        // so there will be a long tail of throws if we enable this now.
-        items: rawResponse.items as AssemblyIndex,
-        count: rawResponse.count,
-      }
     }
 
     return {
-      items: parsedResult.safe,
+      items: rawResponse.items as AssemblyIndex,
       count: rawResponse.count,
     }
   }
@@ -525,22 +527,13 @@ export class Transloadit {
     const parsedResult = zodParseWithContext(assemblyStatusSchema, rawResult)
 
     if (!parsedResult.success) {
-      const err = new InconsistentResponseError(
+      this.maybeThrowInconsistentResponseError(
         `The API responded with data that does not match the expected schema while getting Assembly: ${assemblyId}.\n${parsedResult.humanReadable}`
       )
-      // eslint-disable-next-line no-console
-      console.error(
-        `---\nPlease report this error to Transloadit (support@transloadit.com). We are working on better schemas for our API and this looks like something we do not cover yet: \n\n${err}\nThank you in advance!\n---\n`
-      )
-      // @TODO, once our schemas have matured, we should throw the error here.
-      // But as it stands, schemas are new, and we can't easily update all customer's node-sdks,
-      // so there will be a long tail of throws if we enable this now.
-      checkAssemblyUrls(rawResult as AssemblyStatus)
-      return rawResult as AssemblyStatus
     }
 
-    checkAssemblyUrls(parsedResult.safe)
-    return parsedResult.safe
+    checkAssemblyUrls(rawResult as AssemblyStatus)
+    return rawResult as AssemblyStatus
   }
 
   /**


### PR DESCRIPTION
from https://github.com/transloadit/node-sdk/commit/2465616a54324395eecac61a6a7d338f43c6d2b7

While I agree that we should try to not break people's existing code, I'd argue that it's better to have the SDK throw an error rather than having inconsistent data returned by api2 silently "poison" an app that relies on the node-sdk types for correctness in parsing responses from api2. As a compromise I think an option could do (which we can remove in the future). I'm open for setting it to default `false` though.