### PR TITLE
fix: export assembly instructions types

### DIFF
--- a/src/apiTypes.ts
+++ b/src/apiTypes.ts
@@ -5,6 +5,7 @@ export {
   assemblyIndexItemSchema,
   assemblyStatusSchema,
 } from './alphalib/types/assemblyStatus.ts'
+export type { AssemblyInstructions, AssemblyInstructionsInput } from './alphalib/types/template.ts'
 export { assemblyInstructionsSchema } from './alphalib/types/template.ts'
 
 export interface OptionalAuthParams {


### PR DESCRIPTION
## Summary
- re-export AssemblyInstructions and AssemblyInstructionsInput at the package entry
- keeps docs and migration guide accurate again


Fixes https://github.com/transloadit/node-sdk/issues/264
