### PR TITLE
feat(node): support input-guided image generate intent

### DIFF
--- a/.changeset/image-generate-inputs-v1.md
+++ b/.changeset/image-generate-inputs-v1.md
@@ -1,0 +1,8 @@
+---
+'@transloadit/node': minor
+'@transloadit/mcp-server': patch
+'transloadit': minor
+---
+
+Add input-guided `image generate` intent support, default image generation to
+`google/nano-banana-2`, and document multi-image prompting by filename.

--- a/docs/fingerprint/transloadit-baseline.json
+++ b/docs/fingerprint/transloadit-baseline.json
@@ -1,13 +1,13 @@
 {
   "packageDir": "packages/transloadit",
   "tarball": {
-    "filename": "transloadit-4.7.6.tgz",
-    "sizeBytes": 958306,
-    "sha256": "980961cb6fb4512caf0696e8efb101cbe464faea7b0f86f2d20d63e1bad4b3bc"
+    "filename": "transloadit-4.7.7.tgz",
+    "sizeBytes": 964327,
+    "sha256": "7b6156e32e95689084a3a00feef03339da945eaaad092fe25409dc61bf38ab8f"
   },
   "packageJson": {
     "name": "transloadit",
-    "version": "4.7.6",
+    "version": "4.7.7",
     "main": "./dist/Transloadit.js",
     "exports": {
       ".": "./dist/Transloadit.js",
@@ -353,8 +353,8 @@
     },
     {
       "path": "dist/cli/generateIntentDocs.js",
-      "sizeBytes": 11641,
-      "sha256": "b9b9bf05020ff6c452c3c3fd8b878fba73d4d49cf6ba77714ec0cfad6e763c17"
+      "sizeBytes": 12162,
+      "sha256": "88b738652c7b0ff7d37d3d8977d5ba5fc4ee291862be8b5ebbf25fa2e50f67c2"
     },
     {
       "path": "dist/alphalib/types/robots/google-import.js",
@@ -438,8 +438,13 @@
     },
     {
       "path": "dist/cli/semanticIntents/imageDescribe.js",
-      "sizeBytes": 7347,
-      "sha256": "1ac1b94f250a4c9cf8b37cffaebe49ed0a994ad622a390cf967e9f5858fc13a1"
+      "sizeBytes": 7357,
+      "sha256": "999a39d3ea0108858d4fd86e5f3f6ad36e08d3548075c147767e5dfc15f5917c"
+    },
+    {
+      "path": "dist/cli/semanticIntents/imageGenerate.js",
+      "sizeBytes": 7209,
+      "sha256": "29d6cdd0f26eb4d0225f9b1e9c3b5e61a3ec18fc57c153d26d34d438c500b617"
     },
     {
       "path": "dist/InconsistentResponseError.js",
@@ -453,8 +458,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/index.js",
-      "sizeBytes": 712,
-      "sha256": "b7edabdaa145ba3ebb0e785290303cdceb954645e146855585456e4cf6fafcda"
+      "sizeBytes": 849,
+      "sha256": "aa5dafcdd39b24297629b113b78cfd09b59b7d57fad0b00a6c8ddaa22caa805a"
     },
     {
       "path": "dist/inputFiles.js",
@@ -468,8 +473,8 @@
     },
     {
       "path": "dist/cli/intentCommandSpecs.js",
-      "sizeBytes": 7079,
-      "sha256": "f80fb2fda1b9c0c1cb49f132a5a03aeec51c91961d54973f117403a18547407e"
+      "sizeBytes": 6901,
+      "sha256": "0cdacaa914ee8b41e411a73cbdd69aadc74ec46876a814f01630a0caf3cdaf24"
     },
     {
       "path": "dist/cli/intentFields.js",
@@ -483,8 +488,8 @@
     },
     {
       "path": "dist/cli/intentRuntime.js",
-      "sizeBytes": 16866,
-      "sha256": "1b3f1cd84f162f33e60b7416a4f0be0cbab9d5840ed5f44bec4d7d239e4e9eeb"
+      "sizeBytes": 16959,
+      "sha256": "b7efb156e975f10cf7f544bbb238f2b3a73a694a4dc214edf6829f6b32da1090"
     },
     {
       "path": "dist/lintAssemblyInput.js",
@@ -498,8 +503,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/markdownPdf.js",
-      "sizeBytes": 3562,
-      "sha256": "ddbba834eeb5c592c44a525781ae951ea5e9e3588b855161d42c1a42730b18e3"
+      "sizeBytes": 3572,
+      "sha256": "9005a29884d69f2abe5ae5ff93bd39c2818a7f358b4f4c22e4c3e977e29123ef"
     },
     {
       "path": "dist/alphalib/mcache.js",
@@ -829,7 +834,7 @@
     {
       "path": "package.json",
       "sizeBytes": 2855,
-      "sha256": "b6e241edb89739e05d3babfcf65f1fd7c317c432d5adc72cd875b6bab0599870"
+      "sha256": "5b92b07c9bd1125cd9bcc983de69e2be6fcc364d552479963b64adb3eb9e8148"
     },
     {
       "path": "dist/alphalib/types/robots/_index.d.ts.map",
@@ -1493,13 +1498,13 @@
     },
     {
       "path": "dist/cli/generateIntentDocs.d.ts.map",
-      "sizeBytes": 137,
-      "sha256": "02ea53975f9b3a23e1a818db4c3b755229e06ecf2ae838ff8b5fe672b3127bb3"
+      "sizeBytes": 322,
+      "sha256": "fef7c62b2f31b146d88600a55ae2203411a1cf3e8919754ad9d643090b2b4508"
     },
     {
       "path": "dist/cli/generateIntentDocs.js.map",
-      "sizeBytes": 10178,
-      "sha256": "7871db734d48209977ffbff0f64810ba3d7860700cab6a48a1917fade2731575"
+      "sizeBytes": 10673,
+      "sha256": "0babc761e5669099b7df8af96ccb838ccc20501fe13bae2243c58b681ed3044c"
     },
     {
       "path": "dist/alphalib/types/robots/google-import.d.ts.map",
@@ -1663,13 +1668,23 @@
     },
     {
       "path": "dist/cli/semanticIntents/imageDescribe.d.ts.map",
-      "sizeBytes": 369,
-      "sha256": "f19041239dc6a3a59cba7469b24557feae411c6584483991b92f555dd2c7f76a"
+      "sizeBytes": 417,
+      "sha256": "45b3744a22ac11470947499131da1bd57ca792a7459dbbe7e360551dbf3b22a7"
     },
     {
       "path": "dist/cli/semanticIntents/imageDescribe.js.map",
-      "sizeBytes": 4469,
-      "sha256": "dd5584031d838472d9f2479e63bb437188ca674fa83b81ad948a576d1b52369b"
+      "sizeBytes": 4482,
+      "sha256": "311080203e93682f4676371a9ccda5585287fd9bfd514921d855a75941ab1887"
+    },
+    {
+      "path": "dist/cli/semanticIntents/imageGenerate.d.ts.map",
+      "sizeBytes": 517,
+      "sha256": "467263299f9b7040b7bf0b7bdd24edb9045eaa1206d2c8b6ce59596d8aab4860"
+    },
+    {
+      "path": "dist/cli/semanticIntents/imageGenerate.js.map",
+      "sizeBytes": 5556,
+      "sha256": "5d28662bf582123982c1041d74118a3578e8186fca12c0b0d5ba0fb49c4e0224"
     },
     {
       "path": "dist/InconsistentResponseError.d.ts.map",
@@ -1688,8 +1703,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/index.d.ts.map",
-      "sizeBytes": 844,
-      "sha256": "ba2f0a7b3f8b46fc34a5f42c10ba3aec67f9fd6ad46da5716a3b076977815a9d"
+      "sizeBytes": 891,
+      "sha256": "7c78e7294e3b1dec31f83fabbeeefe1bd5d50b565a2a37242138da34b068f8fb"
     },
     {
       "path": "dist/cli/commands/index.js.map",
@@ -1698,8 +1713,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/index.js.map",
-      "sizeBytes": 564,
-      "sha256": "b2fb3dc5c6996eec5f528988648282e02a7b69c5aae556d354486e08f2197f9e"
+      "sizeBytes": 634,
+      "sha256": "b611ab4e3f47609bfc7d45cd52de226b145230e818f7f96b4b716f84ca7c6f91"
     },
     {
       "path": "dist/inputFiles.d.ts.map",
@@ -1724,12 +1739,12 @@
     {
       "path": "dist/cli/intentCommandSpecs.d.ts.map",
       "sizeBytes": 1276,
-      "sha256": "dd3fa43dbe3163e9b1523d46204f9462a87dcfb57359b8f08a895eb65b52b85b"
+      "sha256": "6524c4b2f3a6782bf15085941df6c6889cf94b79028efb06c4fdd3958c1bd7b3"
     },
     {
       "path": "dist/cli/intentCommandSpecs.js.map",
-      "sizeBytes": 5294,
-      "sha256": "3779e0d063e2751c4ea318fbd00a5c9dbf3641f59eb9695372bff405cf830e06"
+      "sizeBytes": 5221,
+      "sha256": "3a9c072b217efb11d110c754ae0cbc6feec8ac6c3938829c521feda61c2d7329"
     },
     {
       "path": "dist/cli/intentFields.d.ts.map",
@@ -1754,12 +1769,12 @@
     {
       "path": "dist/cli/intentRuntime.d.ts.map",
       "sizeBytes": 4152,
-      "sha256": "a417392d5364cd67c7a943ad30434dde82bdde8ff306c8884c7070d850d0611e"
+      "sha256": "8044ef5b0bfd094911387b8adff021a008f8689eb320050d94dd7e68bc6fc05d"
     },
     {
       "path": "dist/cli/intentRuntime.js.map",
-      "sizeBytes": 14344,
-      "sha256": "36d1a03b18143667a9bf96edbd32372f734be9f3a5e275ad714f9e53a037ca68"
+      "sizeBytes": 14456,
+      "sha256": "2e1413a4d94795419dd66c6ae0f0f2ab2dfe1de22b22b605a2b6a42ec6a79038"
     },
     {
       "path": "dist/lintAssemblyInput.d.ts.map",
@@ -1788,8 +1803,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/markdownPdf.js.map",
-      "sizeBytes": 2115,
-      "sha256": "f5c08b48224d809c8859deb39f41c737dee71dc18930e3a94da6c0c9c3cf805f"
+      "sizeBytes": 2125,
+      "sha256": "0196642319c936540f373c9f68e8ed2922eb5ee16d028e66ac2bed662ac6005a"
     },
     {
       "path": "dist/alphalib/mcache.d.ts.map",
@@ -2443,8 +2458,8 @@
     },
     {
       "path": "README.md",
-      "sizeBytes": 81218,
-      "sha256": "e7777f11b097743c372093bb06d995dab0e876a665dfa6a9fc795ccccfc4f594"
+      "sizeBytes": 84309,
+      "sha256": "6ab0c4d3904d56eb139e9bf290a45591a3428cb2363faf186a27a1bbcdb810d4"
     },
     {
       "path": "dist/alphalib/types/robots/_index.d.ts",
@@ -3108,13 +3123,13 @@
     },
     {
       "path": "dist/cli/generateIntentDocs.d.ts",
-      "sizeBytes": 59,
-      "sha256": "62a1df25d0d6a23b5c59ea877104bd2633759d655e526f1d8be6dde068dca46e"
+      "sizeBytes": 293,
+      "sha256": "7db6474498940960811a88c1b69e6d7ae95ba4699ff0296cda07a7a832030107"
     },
     {
       "path": "src/cli/generateIntentDocs.ts",
-      "sizeBytes": 12046,
-      "sha256": "4e85ded91f8ffa1ce8321d691b7b7941b916313266c3346dc22d23c8178bf59f"
+      "sizeBytes": 12525,
+      "sha256": "24ab29b2a991eaa39fb5af54d477a4a4b998dca3b286bbae86a71ebff461d933"
     },
     {
       "path": "dist/alphalib/types/robots/google-import.d.ts",
@@ -3278,13 +3293,23 @@
     },
     {
       "path": "dist/cli/semanticIntents/imageDescribe.d.ts",
-      "sizeBytes": 1971,
-      "sha256": "c9f9f5d960aa948ce6ee36c7b617cbd157082b581d5a280528e634bc812e170e"
+      "sizeBytes": 2010,
+      "sha256": "51142f1ce2811990fb22fbbcf41cdb37c831c5bd0e2eb13f7ea3e070e09d54fe"
     },
     {
       "path": "src/cli/semanticIntents/imageDescribe.ts",
-      "sizeBytes": 8077,
-      "sha256": "8651a889a6347ca3395d4559bed5c53930450e62c97a28849d7e72f3f3982054"
+      "sizeBytes": 8118,
+      "sha256": "cfa2a61d551e1097ba3503390591d50106427c31cdd768f5082b21b052d2130f"
+    },
+    {
+      "path": "dist/cli/semanticIntents/imageGenerate.d.ts",
+      "sizeBytes": 4104,
+      "sha256": "939c70afe3e980e44a0df932c135058cdbb2d05a47e758936f214aa75f015d65"
+    },
+    {
+      "path": "src/cli/semanticIntents/imageGenerate.ts",
+      "sizeBytes": 7258,
+      "sha256": "f91facf67d03265119b7c19574a08f29808e43d82ddc7fee24804e50b7011b8a"
     },
     {
       "path": "dist/InconsistentResponseError.d.ts",
@@ -3303,8 +3328,8 @@
     },
     {
       "path": "dist/cli/semanticIntents/index.d.ts",
-      "sizeBytes": 904,
-      "sha256": "de820295e77eb98c6aba606d3bcfe8fe81fac231eff1eda173696bbe4bf29243"
+      "sizeBytes": 950,
+      "sha256": "c3809abf8431ecaa7facec8c794f87f03026567a3bbe2099e5becb2723ea6303"
     },
     {
       "path": "src/cli/commands/index.ts",
@@ -3313,8 +3338,8 @@
     },
     {
       "path": "src/cli/semanticIntents/index.ts",
-      "sizeBytes": 1495,
-      "sha256": "63bd75a504db79877cd581c9404b8ad89f96242ece6edd02512f7203f8bf59d7"
+      "sizeBytes": 1675,
+      "sha256": "74f507b90a0b1909344ada1425d6f4e1346ae65427238fee60a44e789288e58f"
     },
     {
       "path": "dist/inputFiles.d.ts",
@@ -3343,8 +3368,8 @@
     },
     {
       "path": "src/cli/intentCommandSpecs.ts",
-      "sizeBytes": 7910,
-      "sha256": "ee7f5b712b51821894001b39327db289dc770fb1aaa24f21bd0069d6fe174b7b"
+      "sizeBytes": 7733,
+      "sha256": "127b076b7f715be5dd0345054d49c7af54f97c1d6a90396fad667897e6fb5cff"
     },
     {
       "path": "dist/cli/intentFields.d.ts",
@@ -3373,8 +3398,8 @@
     },
     {
       "path": "src/cli/intentRuntime.ts",
-      "sizeBytes": 20973,
-      "sha256": "d7e01809348fbf78f710eb0597b03e0e68507130c8b85bbd369649b96da3841d"
+      "sizeBytes": 21158,
+      "sha256": "5fb2087a4875e38d7942f939e4b66d892c7e5ddba711df145f4133440ee8c75f"
     },
     {
       "path": "src/alphalib/typings/json-to-ast.d.ts",
@@ -3408,8 +3433,8 @@
     },
     {
       "path": "src/cli/semanticIntents/markdownPdf.ts",
-      "sizeBytes": 3729,
-      "sha256": "f490142c883fcc314e03f677140f5d8b1476ca6581446c04c540b334a62e35a0"
+      "sizeBytes": 3739,
+      "sha256": "ae0aa2b767b787c68bb06cea8ae5be57d5a4c94a8456dadeaa3e6b1185ba0e60"
     },
     {
       "path": "dist/alphalib/mcache.d.ts",

--- a/docs/fingerprint/transloadit-baseline.package.json
+++ b/docs/fingerprint/transloadit-baseline.package.json
@@ -1,6 +1,6 @@
 {
   "name": "transloadit",
-  "version": "4.7.6",
+  "version": "4.7.7",
   "description": "Node.js SDK for Transloadit",
   "homepage": "https://github.com/transloadit/node-sdk/tree/main/packages/node",
   "bugs": {

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -98,7 +98,7 @@ All intent commands also support the global CLI flags `--json`, `--log-level`, `
 
 | Command | What it does | Input | Output |
 | --- | --- | --- | --- |
-| `image generate` | Generate images from text prompts | none | file |
+| `image generate` | Generate images from text prompts | file, dir, URL, base64 | file |
 | `preview generate` | Generate a preview thumbnail | file, dir, URL, base64 | file |
 | `image remove-background` | Remove the background from images | file, dir, URL, base64 | file |
 | `image optimize` | Optimize images without quality loss | file, dir, URL, base64 | file |
@@ -164,43 +164,49 @@ These flags are available across many intent commands, so the per-command sectio
 
 Generate images from text prompts
 
-Runs `/image/generate` and writes the result to `--out`.
+Runs `/image/generate`. Without inputs, this is text-to-image. With one or more `--input` files, the inputs are bundled into a single assembly so the prompt can refer to them by filename.
 
 **Usage**
 
 ```bash
-npx transloadit image generate [options]
+npx transloadit image generate --input <path|dir|url|-> [options]
 ```
 
 **Quick facts**
 
-- Input: none
+- Input: file, dir, URL, base64
 - Output: file
-- Execution: no input
-- Backend: `/image/generate`
+- Execution: single assembly
+- Backend: semantic alias `image-generate`
 
 **Shared flags**
 
-- Uses the shared output flags listed above.
+- Uses the shared file input and output flags listed above.
+- Also supports the shared base processing flags listed above.
 
 **Command options**
 
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
-| `--model` | `string` | no | `value` | The AI model to use for image generation. Defaults to google/nano-banana. |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
-| `--seed` | `number` | no | `1` | Seed for the random number generator. |
-| `--aspect-ratio` | `string` | no | `value` | Aspect ratio of the generated image. |
-| `--height` | `number` | no | `1` | Height of the generated image. |
-| `--width` | `number` | no | `1` | Width of the generated image. |
-| `--style` | `string` | no | `value` | Style of the generated image. |
-| `--num-outputs` | `number` | no | `1` | Number of image variants to generate. |
+| `--seed` | `number` | no | — | Seed for the random number generator. |
+| `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
+| `--height` | `number` | no | — | Height of the generated image. |
+| `--width` | `number` | no | — | Width of the generated image. |
+| `--style` | `string` | no | — | Style of the generated image. |
+| `--num-outputs` | `number` | no | — | Number of image variants to generate. |
 
 **Examples**
 
 ```bash
+# Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --out output.png
+# Guide generation with one input image
+transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --out output.png
+# Guide generation with multiple input images
+transloadit image generate --input person1.jpg --input person2.jpg --input background.jpg --prompt "Place person1.jpg feeding person2.jpg in front of background.jpg" --out output.png
 ```
 
 #### `preview generate`
@@ -236,6 +242,7 @@ npx transloadit preview generate --input <path|dir|url|-> [options]
 | `--height` | `number` | no | `1` | Height of the thumbnail, in pixels. |
 | `--resize-strategy` | `string` | no | `crop` | To achieve the desired dimensions of the preview thumbnail, the Robot might have to resize the generated image. |
 | `--background` | `string` | no | `value` | The hexadecimal code of the color used to fill the background (only used for the pad resize strategy). |
+| `--zoom` | `boolean` | no | `true` | If set to false, smaller images will not be stretched to the desired width and height. |
 | `--strategy` | `json` | no | `value` | Definition of the thumbnail generation process per file category. |
 | `--artwork-outer-color` | `string` | no | `value` | The color used in the outer parts of the artwork's gradient. |
 | `--artwork-center-color` | `string` | no | `value` | The color used in the center of the artwork's gradient. |
@@ -291,7 +298,7 @@ npx transloadit image remove-background --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--select` | `string` | no | `foreground` | Region to select and keep in the image. The other region is removed. |
-| `--format` | `string` | no | `png` | Format of the generated image. |
+| `--format` | `string` | no | `png` | Format of the generated image. Defaults to PNG when not provided. |
 | `--provider` | `string` | no | `aws` | Provider to use for removing the background. |
 | `--model` | `string` | no | `value` | Provider-specific model to use for removing the background. Mostly intended for testing and evaluation. |
 
@@ -333,6 +340,7 @@ npx transloadit image optimize --input <path|dir|url|-> [options]
 | `--progressive` | `boolean` | no | `true` | Interlaces the image if set to true, which makes the result image load progressively in browsers. |
 | `--preserve-meta-data` | `boolean` | no | `true` | Specifies if the image's metadata should be preserved during the optimization, or not. |
 | `--fix-breaking-images` | `boolean` | no | `true` | If set to true this parameter tries to fix images that would otherwise make the underlying tool error out and thereby break your Assemblies . |
+| `--lossy` | `boolean` | no | `true` | When set to false (the default), only lossless PNG optimizers are used, disabling pngquant to preserve color accuracy. |
 
 **Examples**
 
@@ -410,6 +418,7 @@ npx transloadit image resize --input <path|dir|url|-> [options]
 | `--trim-whitespace` | `boolean` | no | `true` | This determines if additional whitespace around the image should first be trimmed away. |
 | `--clip` | `auto` | no | `value` | Apply the clipping path to other operations in the resize job, if one is present. |
 | `--negate` | `boolean` | no | `true` | Replace each pixel with its complementary color, effectively negating the image. Especially useful when testing clipping. |
+| `--clut` | `boolean` | no | `true` | Applies a Color Look-Up Table (CLUT) image to remap the colors of the input image using ImageMagick's -clut operator. |
 | `--density` | `string` | no | `value` | While in-memory quality and file format depth specifies the color resolution, the density of an image is the spatial (space) resolution of the image. |
 | `--monochrome` | `boolean` | no | `true` | Transform the image to black and white. This is a shortcut for setting the colorspace to Gray and type to Bilevel. |
 | `--shave` | `auto` | no | `value` | Shave pixels from the image edges. The value should be in the format width or widthxheight to specify the number of pixels to remove from each side. |
@@ -565,6 +574,7 @@ npx transloadit document thumbs --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--page` | `number` | no | `1` | The PDF page that you want to convert to an image. By default the value is null which means that all pages will be converted into images. |
+| `--page-range` | `string` | no | `value` | A page range to extract, in the format "start-end" (e.g., "1-20"). |
 | `--format` | `string` | no | `jpg` | The format of the extracted image(s). If you specify the value "gif", then an animated gif cycling through all pages is created. Please check out this demo to learn more about… |
 | `--delay` | `number` | no | `1` | If your output format is "gif" then this parameter sets the number of 100th seconds to pass before the next frame is shown in the animation. |
 | `--width` | `number` | no | `1` | Width of the new image, in pixels. If not specified, will default to the width of the input image |
@@ -577,7 +587,7 @@ npx transloadit document thumbs --input <path|dir|url|-> [options]
 | `--colorspace` | `string` | no | `CMY` | Sets the image colorspace. For details about the available values, see the ImageMagick documentation. Please note that if you were using "RGB", we recommend using "sRGB".… |
 | `--trim-whitespace` | `boolean` | no | `true` | This determines if additional whitespace around the PDF should first be trimmed away before it is converted to an image. |
 | `--pdf-use-cropbox` | `boolean` | no | `true` | Some PDF documents lie about their dimensions. For instance they'll say they are landscape, but when opened in decent Desktop readers, it's really in portrait mode. This can… |
-| `--turbo` | `boolean` | no | `true` | If you set this to false, the robot will not emit files as they become available. |
+| `--turbo` | `boolean` | no | `true` | Enables high-performance mode for faster document processing. |
 
 **Examples**
 
@@ -614,14 +624,14 @@ npx transloadit audio waveform --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--ffmpeg` | `json` | no | `value` | A parameter object to be passed to FFmpeg. If a preset is used, the options specified are merged on top of the ones from the preset. For available options, see the FFmpeg… |
-| `--format` | `string` | no | `image` | The format of the result file. Can be "image" or "json". If "image" is supplied, a PNG image will be created, otherwise a JSON file. |
+| `--format` | `string` | no | `image` | The format of the result file. Can be "image" or "json". If "image" is supplied, a PNG image will be created, otherwise a JSON file. When style is "spectrogram", only "image" is… |
 | `--width` | `number` | no | `1` | The width of the resulting image if the format "image" was selected. |
 | `--height` | `number` | no | `1` | The height of the resulting image if the format "image" was selected. |
 | `--antialiasing` | `auto` | no | `0` | Either a value of 0 or 1, or true/false, corresponding to if you want to enable antialiasing to achieve smoother edges in the waveform graph or not. |
 | `--background-color` | `string` | no | `value` | The background color of the resulting image in the "rrggbbaa" format (red, green, blue, alpha), if the format "image" was selected. |
 | `--center-color` | `string` | no | `value` | The color used in the center of the gradient. The format is "rrggbbaa" (red, green, blue, alpha). |
 | `--outer-color` | `string` | no | `value` | The color used in the outer parts of the gradient. The format is "rrggbbaa" (red, green, blue, alpha). |
-| `--style` | `string` | no | `v0` | Waveform style version. - "v0": Legacy waveform generation (default). - "v1": Advanced waveform generation with additional parameters. For backwards compatibility, numeric values… |
+| `--style` | `string` | no | `v0` | Waveform style version. - "v0": Legacy waveform generation (default). - "v1": Advanced waveform generation with additional parameters. - "spectrogram": Spectrogram visualization… |
 | `--split-channels` | `boolean` | no | `true` | Available when style is "v1". If set to true, outputs multi-channel waveform data or image files, one per channel. |
 | `--zoom` | `number` | no | `1` | Available when style is "v1". Zoom level in samples per pixel. This parameter cannot be used together with pixels_per_second. |
 | `--pixels-per-second` | `number` | no | `1` | Available when style is "v1". Zoom level in pixels per second. This parameter cannot be used together with zoom. |
@@ -639,6 +649,13 @@ npx transloadit audio waveform --input <path|dir|url|-> [options]
 | `--with-axis-labels` | `boolean` | no | `true` | Available when style is "v1". If set to true, renders waveform image with axis labels. |
 | `--amplitude-scale` | `number` | no | `1` | Available when style is "v1". Amplitude scale factor. |
 | `--compression` | `number` | no | `1` | Available when style is "v1". PNG compression level: 0 (none) to 9 (best), or -1 (default). Only applicable when format is "image". |
+| `--color-map` | `string` | no | `viridis` | Available when style is "spectrogram". Color scheme for the spectrogram visualization. Defaults to "viridis". |
+| `--frequency-scale` | `string` | no | `linear` | Available when style is "spectrogram". Frequency scale for the spectrogram. "linear" shows frequencies evenly spaced, "logarithmic" emphasizes lower frequencies. Defaults to… |
+| `--frequency-min` | `number` | no | `1` | Available when style is "spectrogram". Minimum frequency in Hz to display. Defaults to 0. |
+| `--frequency-max` | `number` | no | `1` | Available when style is "spectrogram". Maximum frequency in Hz to display. Defaults to half the sample rate (Nyquist frequency). |
+| `--legend` | `boolean` | no | `true` | Available when style is "spectrogram". Whether to include a legend showing the frequency and time scales. Defaults to false. |
+| `--gain` | `number` | no | `1` | Available when style is "spectrogram". Linear gain factor for spectrogram intensity. Defaults to 1. |
+| `--orientation` | `string` | no | `vertical` | Available when style is "spectrogram". Orientation of the spectrogram. "horizontal" shows time on the x-axis (default), "vertical" shows time on the y-axis. |
 
 **Examples**
 
@@ -918,6 +935,7 @@ npx transloadit file compress --input <path|dir|url|-> [options]
 | `--compression-level` | `number` | no | `1` | Determines how fiercely to try to compress the archive. -0 is compressionless, which is suitable for media that is already compressed. -1 is fastest with lowest compression. -9… |
 | `--file-layout` | `string` | no | `advanced` | Determines if the result archive should contain all files in one directory (value for this is "simple") or in subfolders according to the explanation below (value for this is… |
 | `--archive-name` | `string` | no | `value` | The name of the archive file to be created (without the file extension). |
+| `--path` | `string` | no | `value` | The path at which each file is to be placed inside the archive. |
 
 **Examples**
 
@@ -948,6 +966,13 @@ npx transloadit file decompress --input <path|dir|url|-> [options]
 
 - Uses the shared file input and output flags listed above.
 - Also supports the shared base processing flags, watch flags, bundling flags listed above.
+
+**Command options**
+
+| Flag | Type | Required | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--password` | `string` | no | `value` | The password to use for decrypting password-protected archives. |
+| `--turbo` | `boolean` | no | `true` | Enables Turbo Mode for /file/decompress. This setting defaults to true. Set it to false to disable Turbo Mode. When enabled, extracted files are emitted as soon as they are… |
 
 **Examples**
 
@@ -1731,6 +1756,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -169,7 +169,7 @@ Runs `/image/generate`. Without inputs, this is text-to-image. With one or more 
 **Usage**
 
 ```bash
-npx transloadit image generate --input <path|dir|url|-> [options]
+npx transloadit image generate [--input <path|dir|url|->] [options]
 ```
 
 **Quick facts**
@@ -672,7 +672,7 @@ Runs `/text/speak` on each input file and writes the result to `--out`.
 **Usage**
 
 ```bash
-npx transloadit text speak --input <path|dir|url|-> [options]
+npx transloadit text speak [--input <path|dir|url|->] [options]
 ```
 
 **Quick facts**
@@ -1756,6 +1756,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 

--- a/packages/node/docs/intent-commands.md
+++ b/packages/node/docs/intent-commands.md
@@ -81,7 +81,7 @@ Runs `/image/generate`. Without inputs, this is text-to-image. With one or more 
 **Usage**
 
 ```bash
-npx transloadit image generate --input <path|dir|url|-> [options]
+npx transloadit image generate [--input <path|dir|url|->] [options]
 ```
 
 **Quick facts**
@@ -584,7 +584,7 @@ Runs `/text/speak` on each input file and writes the result to `--out`.
 **Usage**
 
 ```bash
-npx transloadit text speak --input <path|dir|url|-> [options]
+npx transloadit text speak [--input <path|dir|url|->] [options]
 ```
 
 **Quick facts**

--- a/packages/node/docs/intent-commands.md
+++ b/packages/node/docs/intent-commands.md
@@ -10,7 +10,7 @@ All intent commands also support the global CLI flags `--json`, `--log-level`, `
 
 | Command | What it does | Input | Output |
 | --- | --- | --- | --- |
-| `image generate` | Generate images from text prompts | none | file |
+| `image generate` | Generate images from text prompts | file, dir, URL, base64 | file |
 | `preview generate` | Generate a preview thumbnail | file, dir, URL, base64 | file |
 | `image remove-background` | Remove the background from images | file, dir, URL, base64 | file |
 | `image optimize` | Optimize images without quality loss | file, dir, URL, base64 | file |
@@ -76,43 +76,49 @@ These flags are available across many intent commands, so the per-command sectio
 
 Generate images from text prompts
 
-Runs `/image/generate` and writes the result to `--out`.
+Runs `/image/generate`. Without inputs, this is text-to-image. With one or more `--input` files, the inputs are bundled into a single assembly so the prompt can refer to them by filename.
 
 **Usage**
 
 ```bash
-npx transloadit image generate [options]
+npx transloadit image generate --input <path|dir|url|-> [options]
 ```
 
 **Quick facts**
 
-- Input: none
+- Input: file, dir, URL, base64
 - Output: file
-- Execution: no input
-- Backend: `/image/generate`
+- Execution: single assembly
+- Backend: semantic alias `image-generate`
 
 **Shared flags**
 
-- Uses the shared output flags listed above.
+- Uses the shared file input and output flags listed above.
+- Also supports the shared base processing flags listed above.
 
 **Command options**
 
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
-| `--model` | `string` | no | `value` | The AI model to use for image generation. Defaults to google/nano-banana. |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
-| `--seed` | `number` | no | `1` | Seed for the random number generator. |
-| `--aspect-ratio` | `string` | no | `value` | Aspect ratio of the generated image. |
-| `--height` | `number` | no | `1` | Height of the generated image. |
-| `--width` | `number` | no | `1` | Width of the generated image. |
-| `--style` | `string` | no | `value` | Style of the generated image. |
-| `--num-outputs` | `number` | no | `1` | Number of image variants to generate. |
+| `--seed` | `number` | no | — | Seed for the random number generator. |
+| `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
+| `--height` | `number` | no | — | Height of the generated image. |
+| `--width` | `number` | no | — | Width of the generated image. |
+| `--style` | `string` | no | — | Style of the generated image. |
+| `--num-outputs` | `number` | no | — | Number of image variants to generate. |
 
 **Examples**
 
 ```bash
+# Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --out output.png
+# Guide generation with one input image
+transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --out output.png
+# Guide generation with multiple input images
+transloadit image generate --input person1.jpg --input person2.jpg --input background.jpg --prompt "Place person1.jpg feeding person2.jpg in front of background.jpg" --out output.png
 ```
 
 ## `preview generate`
@@ -148,6 +154,7 @@ npx transloadit preview generate --input <path|dir|url|-> [options]
 | `--height` | `number` | no | `1` | Height of the thumbnail, in pixels. |
 | `--resize-strategy` | `string` | no | `crop` | To achieve the desired dimensions of the preview thumbnail, the Robot might have to resize the generated image. |
 | `--background` | `string` | no | `value` | The hexadecimal code of the color used to fill the background (only used for the pad resize strategy). |
+| `--zoom` | `boolean` | no | `true` | If set to false, smaller images will not be stretched to the desired width and height. |
 | `--strategy` | `json` | no | `value` | Definition of the thumbnail generation process per file category. |
 | `--artwork-outer-color` | `string` | no | `value` | The color used in the outer parts of the artwork's gradient. |
 | `--artwork-center-color` | `string` | no | `value` | The color used in the center of the artwork's gradient. |
@@ -203,7 +210,7 @@ npx transloadit image remove-background --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--select` | `string` | no | `foreground` | Region to select and keep in the image. The other region is removed. |
-| `--format` | `string` | no | `png` | Format of the generated image. |
+| `--format` | `string` | no | `png` | Format of the generated image. Defaults to PNG when not provided. |
 | `--provider` | `string` | no | `aws` | Provider to use for removing the background. |
 | `--model` | `string` | no | `value` | Provider-specific model to use for removing the background. Mostly intended for testing and evaluation. |
 
@@ -245,6 +252,7 @@ npx transloadit image optimize --input <path|dir|url|-> [options]
 | `--progressive` | `boolean` | no | `true` | Interlaces the image if set to true, which makes the result image load progressively in browsers. |
 | `--preserve-meta-data` | `boolean` | no | `true` | Specifies if the image's metadata should be preserved during the optimization, or not. |
 | `--fix-breaking-images` | `boolean` | no | `true` | If set to true this parameter tries to fix images that would otherwise make the underlying tool error out and thereby break your Assemblies . |
+| `--lossy` | `boolean` | no | `true` | When set to false (the default), only lossless PNG optimizers are used, disabling pngquant to preserve color accuracy. |
 
 **Examples**
 
@@ -322,6 +330,7 @@ npx transloadit image resize --input <path|dir|url|-> [options]
 | `--trim-whitespace` | `boolean` | no | `true` | This determines if additional whitespace around the image should first be trimmed away. |
 | `--clip` | `auto` | no | `value` | Apply the clipping path to other operations in the resize job, if one is present. |
 | `--negate` | `boolean` | no | `true` | Replace each pixel with its complementary color, effectively negating the image. Especially useful when testing clipping. |
+| `--clut` | `boolean` | no | `true` | Applies a Color Look-Up Table (CLUT) image to remap the colors of the input image using ImageMagick's -clut operator. |
 | `--density` | `string` | no | `value` | While in-memory quality and file format depth specifies the color resolution, the density of an image is the spatial (space) resolution of the image. |
 | `--monochrome` | `boolean` | no | `true` | Transform the image to black and white. This is a shortcut for setting the colorspace to Gray and type to Bilevel. |
 | `--shave` | `auto` | no | `value` | Shave pixels from the image edges. The value should be in the format width or widthxheight to specify the number of pixels to remove from each side. |
@@ -477,6 +486,7 @@ npx transloadit document thumbs --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--page` | `number` | no | `1` | The PDF page that you want to convert to an image. By default the value is null which means that all pages will be converted into images. |
+| `--page-range` | `string` | no | `value` | A page range to extract, in the format "start-end" (e.g., "1-20"). |
 | `--format` | `string` | no | `jpg` | The format of the extracted image(s). If you specify the value "gif", then an animated gif cycling through all pages is created. Please check out this demo to learn more about… |
 | `--delay` | `number` | no | `1` | If your output format is "gif" then this parameter sets the number of 100th seconds to pass before the next frame is shown in the animation. |
 | `--width` | `number` | no | `1` | Width of the new image, in pixels. If not specified, will default to the width of the input image |
@@ -489,7 +499,7 @@ npx transloadit document thumbs --input <path|dir|url|-> [options]
 | `--colorspace` | `string` | no | `CMY` | Sets the image colorspace. For details about the available values, see the ImageMagick documentation. Please note that if you were using "RGB", we recommend using "sRGB".… |
 | `--trim-whitespace` | `boolean` | no | `true` | This determines if additional whitespace around the PDF should first be trimmed away before it is converted to an image. |
 | `--pdf-use-cropbox` | `boolean` | no | `true` | Some PDF documents lie about their dimensions. For instance they'll say they are landscape, but when opened in decent Desktop readers, it's really in portrait mode. This can… |
-| `--turbo` | `boolean` | no | `true` | If you set this to false, the robot will not emit files as they become available. |
+| `--turbo` | `boolean` | no | `true` | Enables high-performance mode for faster document processing. |
 
 **Examples**
 
@@ -526,14 +536,14 @@ npx transloadit audio waveform --input <path|dir|url|-> [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--ffmpeg` | `json` | no | `value` | A parameter object to be passed to FFmpeg. If a preset is used, the options specified are merged on top of the ones from the preset. For available options, see the FFmpeg… |
-| `--format` | `string` | no | `image` | The format of the result file. Can be "image" or "json". If "image" is supplied, a PNG image will be created, otherwise a JSON file. |
+| `--format` | `string` | no | `image` | The format of the result file. Can be "image" or "json". If "image" is supplied, a PNG image will be created, otherwise a JSON file. When style is "spectrogram", only "image" is… |
 | `--width` | `number` | no | `1` | The width of the resulting image if the format "image" was selected. |
 | `--height` | `number` | no | `1` | The height of the resulting image if the format "image" was selected. |
 | `--antialiasing` | `auto` | no | `0` | Either a value of 0 or 1, or true/false, corresponding to if you want to enable antialiasing to achieve smoother edges in the waveform graph or not. |
 | `--background-color` | `string` | no | `value` | The background color of the resulting image in the "rrggbbaa" format (red, green, blue, alpha), if the format "image" was selected. |
 | `--center-color` | `string` | no | `value` | The color used in the center of the gradient. The format is "rrggbbaa" (red, green, blue, alpha). |
 | `--outer-color` | `string` | no | `value` | The color used in the outer parts of the gradient. The format is "rrggbbaa" (red, green, blue, alpha). |
-| `--style` | `string` | no | `v0` | Waveform style version. - "v0": Legacy waveform generation (default). - "v1": Advanced waveform generation with additional parameters. For backwards compatibility, numeric values… |
+| `--style` | `string` | no | `v0` | Waveform style version. - "v0": Legacy waveform generation (default). - "v1": Advanced waveform generation with additional parameters. - "spectrogram": Spectrogram visualization… |
 | `--split-channels` | `boolean` | no | `true` | Available when style is "v1". If set to true, outputs multi-channel waveform data or image files, one per channel. |
 | `--zoom` | `number` | no | `1` | Available when style is "v1". Zoom level in samples per pixel. This parameter cannot be used together with pixels_per_second. |
 | `--pixels-per-second` | `number` | no | `1` | Available when style is "v1". Zoom level in pixels per second. This parameter cannot be used together with zoom. |
@@ -551,6 +561,13 @@ npx transloadit audio waveform --input <path|dir|url|-> [options]
 | `--with-axis-labels` | `boolean` | no | `true` | Available when style is "v1". If set to true, renders waveform image with axis labels. |
 | `--amplitude-scale` | `number` | no | `1` | Available when style is "v1". Amplitude scale factor. |
 | `--compression` | `number` | no | `1` | Available when style is "v1". PNG compression level: 0 (none) to 9 (best), or -1 (default). Only applicable when format is "image". |
+| `--color-map` | `string` | no | `viridis` | Available when style is "spectrogram". Color scheme for the spectrogram visualization. Defaults to "viridis". |
+| `--frequency-scale` | `string` | no | `linear` | Available when style is "spectrogram". Frequency scale for the spectrogram. "linear" shows frequencies evenly spaced, "logarithmic" emphasizes lower frequencies. Defaults to… |
+| `--frequency-min` | `number` | no | `1` | Available when style is "spectrogram". Minimum frequency in Hz to display. Defaults to 0. |
+| `--frequency-max` | `number` | no | `1` | Available when style is "spectrogram". Maximum frequency in Hz to display. Defaults to half the sample rate (Nyquist frequency). |
+| `--legend` | `boolean` | no | `true` | Available when style is "spectrogram". Whether to include a legend showing the frequency and time scales. Defaults to false. |
+| `--gain` | `number` | no | `1` | Available when style is "spectrogram". Linear gain factor for spectrogram intensity. Defaults to 1. |
+| `--orientation` | `string` | no | `vertical` | Available when style is "spectrogram". Orientation of the spectrogram. "horizontal" shows time on the x-axis (default), "vertical" shows time on the y-axis. |
 
 **Examples**
 
@@ -830,6 +847,7 @@ npx transloadit file compress --input <path|dir|url|-> [options]
 | `--compression-level` | `number` | no | `1` | Determines how fiercely to try to compress the archive. -0 is compressionless, which is suitable for media that is already compressed. -1 is fastest with lowest compression. -9… |
 | `--file-layout` | `string` | no | `advanced` | Determines if the result archive should contain all files in one directory (value for this is "simple") or in subfolders according to the explanation below (value for this is… |
 | `--archive-name` | `string` | no | `value` | The name of the archive file to be created (without the file extension). |
+| `--path` | `string` | no | `value` | The path at which each file is to be placed inside the archive. |
 
 **Examples**
 
@@ -860,6 +878,13 @@ npx transloadit file decompress --input <path|dir|url|-> [options]
 
 - Uses the shared file input and output flags listed above.
 - Also supports the shared base processing flags, watch flags, bundling flags listed above.
+
+**Command options**
+
+| Flag | Type | Required | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--password` | `string` | no | `value` | The password to use for decrypting password-protected archives. |
+| `--turbo` | `boolean` | no | `true` | Enables Turbo Mode for /file/decompress. This setting defaults to true. Set it to false to disable Turbo Mode. When enabled, extracted files are emitted as soon as they are… |
 
 **Examples**
 

--- a/packages/node/src/cli/generateIntentDocs.ts
+++ b/packages/node/src/cli/generateIntentDocs.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import {
   getConcurrencyOptionDocumentation,
   getDeleteAfterProcessingOptionDocumentation,
@@ -127,7 +128,14 @@ function getBackendSummary(catalogDefinition: IntentDefinition): string {
 function getUsage(definition: ResolvedIntentCommandDefinition): string {
   const parts = ['npx transloadit', ...definition.paths]
   if (definition.runnerKind !== 'no-input') {
-    parts.push('--input', '<path|dir|url|->')
+    if (
+      'inputPolicy' in definition.intentDefinition &&
+      definition.intentDefinition.inputPolicy.kind === 'optional'
+    ) {
+      parts.push('[--input', '<path|dir|url|->]')
+    } else {
+      parts.push('--input', '<path|dir|url|->')
+    }
   }
   parts.push('[options]')
   return parts.join(' ')
@@ -322,7 +330,7 @@ function renderAtAGlanceTable(definitions: ResolvedIntentCommandDefinition[]): s
   )
 }
 
-function renderIntentDocsBody({
+export function renderIntentDocsBody({
   definitions,
   headingLevel,
 }: {
@@ -357,6 +365,15 @@ function renderIntentDocsBody({
   }
 
   return lines.join('\n').trim()
+}
+
+function isEntrypoint(): boolean {
+  const entrypoint = process.argv[1]
+  if (entrypoint == null) {
+    return false
+  }
+
+  return import.meta.url === pathToFileURL(entrypoint).href
 }
 
 function replaceGeneratedBlock({
@@ -410,10 +427,12 @@ async function main(): Promise<void> {
   await writeFile(readmeUrl, `${nextReadme}\n`)
 }
 
-main().catch((error) => {
-  if (!(error instanceof Error)) {
-    throw new Error(`Was thrown a non-error: ${String(error)}`)
-  }
-  console.error(error)
-  process.exit(1)
-})
+if (isEntrypoint()) {
+  main().catch((error) => {
+    if (!(error instanceof Error)) {
+      throw new Error(`Was thrown a non-error: ${String(error)}`)
+    }
+    console.error(error)
+    process.exit(1)
+  })
+}

--- a/packages/node/src/cli/intentCommandSpecs.ts
+++ b/packages/node/src/cli/intentCommandSpecs.ts
@@ -38,10 +38,6 @@ import {
   meta as robotImageBgremoveMeta,
 } from '../alphalib/types/robots/image-bgremove.ts'
 import {
-  robotImageGenerateInstructionsSchema,
-  meta as robotImageGenerateMeta,
-} from '../alphalib/types/robots/image-generate.ts'
-import {
   robotImageOptimizeInstructionsSchema,
   meta as robotImageOptimizeMeta,
 } from '../alphalib/types/robots/image-optimize.ts'
@@ -169,11 +165,10 @@ export function findIntentDefinitionByPaths(
 }
 
 export const intentCatalog = [
-  defineRobotIntent({
-    kind: 'robot',
-    robot: '/image/generate',
-    meta: robotImageGenerateMeta,
-    schema: robotImageGenerateInstructionsSchema,
+  defineSemanticIntent({
+    kind: 'semantic',
+    paths: ['image', 'generate'],
+    semantic: 'image-generate',
   }),
   defineRobotIntent({
     kind: 'robot',

--- a/packages/node/src/cli/intentRuntime.ts
+++ b/packages/node/src/cli/intentRuntime.ts
@@ -318,8 +318,9 @@ function createSingleStep(
 function createDynamicIntentStep(
   execution: IntentDynamicStepExecutionDefinition,
   rawValues: Record<string, unknown>,
+  hasInputs: boolean,
 ): Record<string, unknown> {
-  return getSemanticIntentDescriptor(execution.handler).createStep(rawValues)
+  return getSemanticIntentDescriptor(execution.handler).createStep(rawValues, { hasInputs })
 }
 
 function requiresLocalInput(
@@ -367,7 +368,11 @@ async function executeIntentCommand({
                     rawValues,
                     createOptions.inputs.length > 0,
                   )
-                : createDynamicIntentStep(definition.execution, rawValues),
+                : createDynamicIntentStep(
+                    definition.execution,
+                    rawValues,
+                    createOptions.inputs.length > 0,
+                  ),
           } as AssembliesCreateOptions['stepsData'],
         }
 
@@ -563,7 +568,7 @@ abstract class GeneratedFileIntentCommandBase extends GeneratedIntentCommandBase
 
     const execution = this.getIntentDefinition().execution
     if (execution.kind === 'dynamic-step') {
-      createDynamicIntentStep(execution, rawValues)
+      createDynamicIntentStep(execution, rawValues, this.getProvidedInputCount() > 0)
     }
 
     return undefined

--- a/packages/node/src/cli/semanticIntents/imageDescribe.ts
+++ b/packages/node/src/cli/semanticIntents/imageDescribe.ts
@@ -212,7 +212,10 @@ function buildDescribeAiChatMessages({
   }
 }
 
-function createImageDescribeStep(rawValues: Record<string, unknown>): Record<string, unknown> {
+function createImageDescribeStep(
+  rawValues: Record<string, unknown>,
+  _context: { hasInputs: boolean },
+): Record<string, unknown> {
   const { fields, profile } = resolveImageDescribeRequest(rawValues)
   if (fields.length === 1 && fields[0] === 'labels') {
     return {

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -1,0 +1,209 @@
+import type { IntentOptionDefinition } from '../intentRuntime.ts'
+import type { SemanticIntentDescriptor, SemanticIntentPresentation } from './index.ts'
+import { parseOptionalEnumValue } from './parsing.ts'
+
+const imageGenerateFormats = ['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg'] as const
+
+const imageGenerateOptionDefinitions = [
+  {
+    name: 'prompt',
+    kind: 'string',
+    propertyName: 'prompt',
+    optionFlags: '--prompt',
+    description: 'The prompt describing the desired image content.',
+    required: false,
+    exampleValue: JSON.stringify('A red bicycle in a studio'),
+  },
+  {
+    name: 'model',
+    kind: 'string',
+    propertyName: 'model',
+    optionFlags: '--model',
+    description: 'The AI model to use for image generation.',
+    required: false,
+  },
+  {
+    name: 'format',
+    kind: 'string',
+    propertyName: 'format',
+    optionFlags: '--format',
+    description: 'Format of the generated image.',
+    required: false,
+    exampleValue: 'jpg',
+  },
+  {
+    name: 'seed',
+    kind: 'number',
+    propertyName: 'seed',
+    optionFlags: '--seed',
+    description: 'Seed for the random number generator.',
+    required: false,
+  },
+  {
+    name: 'aspectRatio',
+    kind: 'string',
+    propertyName: 'aspectRatio',
+    optionFlags: '--aspect-ratio',
+    description: 'Aspect ratio of the generated image.',
+    required: false,
+  },
+  {
+    name: 'height',
+    kind: 'number',
+    propertyName: 'height',
+    optionFlags: '--height',
+    description: 'Height of the generated image.',
+    required: false,
+  },
+  {
+    name: 'width',
+    kind: 'number',
+    propertyName: 'width',
+    optionFlags: '--width',
+    description: 'Width of the generated image.',
+    required: false,
+  },
+  {
+    name: 'style',
+    kind: 'string',
+    propertyName: 'style',
+    optionFlags: '--style',
+    description: 'Style of the generated image.',
+    required: false,
+  },
+  {
+    name: 'numOutputs',
+    kind: 'number',
+    propertyName: 'numOutputs',
+    optionFlags: '--num-outputs',
+    description: 'Number of image variants to generate.',
+    required: false,
+  },
+] as const satisfies readonly IntentOptionDefinition[]
+
+const imageGenerateCommandPresentation = {
+  description: 'Generate images from text prompts',
+  details:
+    'Runs `/image/generate`. Without inputs, this is text-to-image. With one or more `--input` files, the inputs are bundled into a single assembly so the prompt can refer to them by filename.',
+  examples: [
+    [
+      'Generate an image from text',
+      'transloadit image generate --prompt "A red bicycle in a studio" --out output.png',
+    ],
+    [
+      'Guide generation with one input image',
+      'transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --out output.png',
+    ],
+    [
+      'Guide generation with multiple input images',
+      'transloadit image generate --input person1.jpg --input person2.jpg --input background.jpg --prompt "Place person1.jpg feeding person2.jpg in front of background.jpg" --out output.png',
+    ],
+  ] as Array<[string, string]>,
+} as const satisfies SemanticIntentPresentation
+
+function parseOptionalFormat(value: unknown): (typeof imageGenerateFormats)[number] | null {
+  return parseOptionalEnumValue({
+    flagName: '--format',
+    supportedValues: imageGenerateFormats,
+    value,
+  })
+}
+
+function parseRequiredPrompt(value: unknown): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error('image generate requires --prompt')
+  }
+
+  return value
+}
+
+function parseOptionalNumber(flagName: string, value: unknown): number | undefined {
+  if (value == null || value === '') {
+    return undefined
+  }
+
+  const numericValue = typeof value === 'number' ? value : Number.parseFloat(String(value).trim())
+  if (Number.isNaN(numericValue)) {
+    throw new Error(`${flagName} must be a number`)
+  }
+
+  return numericValue
+}
+
+function createImageGenerateStep(
+  rawValues: Record<string, unknown>,
+  context: { hasInputs: boolean },
+): Record<string, unknown> {
+  const step: Record<string, unknown> = {
+    robot: '/image/generate',
+    result: true,
+    prompt: parseRequiredPrompt(rawValues.prompt),
+  }
+
+  if (context.hasInputs) {
+    step.use = {
+      steps: [':original'],
+      bundle_steps: true,
+    }
+  }
+
+  const model = rawValues.model
+  if (typeof model === 'string' && model.trim() !== '') {
+    step.model = model
+  }
+
+  const format = parseOptionalFormat(rawValues.format)
+  if (format != null) {
+    step.format = format
+  }
+
+  const seed = parseOptionalNumber('--seed', rawValues.seed)
+  if (seed != null) {
+    step.seed = seed
+  }
+
+  const aspectRatio = rawValues.aspectRatio
+  if (typeof aspectRatio === 'string' && aspectRatio.trim() !== '') {
+    step.aspect_ratio = aspectRatio
+  }
+
+  const height = parseOptionalNumber('--height', rawValues.height)
+  if (height != null) {
+    step.height = height
+  }
+
+  const width = parseOptionalNumber('--width', rawValues.width)
+  if (width != null) {
+    step.width = width
+  }
+
+  const style = rawValues.style
+  if (typeof style === 'string' && style.trim() !== '') {
+    step.style = style
+  }
+
+  const numOutputs = parseOptionalNumber('--num-outputs', rawValues.numOutputs)
+  if (numOutputs != null) {
+    step.num_outputs = numOutputs
+  }
+
+  return step
+}
+
+export const imageGenerateSemanticIntentDescriptor = {
+  createStep: createImageGenerateStep,
+  execution: {
+    kind: 'dynamic-step',
+    handler: 'image-generate',
+    resultStepName: 'generate',
+    fields: imageGenerateOptionDefinitions,
+  },
+  inputPolicy: {
+    kind: 'optional',
+    field: 'prompt',
+    attachUseWhenInputsProvided: false,
+  },
+  outputDescription: 'Write the result to this path',
+  presentation: imageGenerateCommandPresentation,
+  runnerKind: 'bundled',
+} as const satisfies SemanticIntentDescriptor

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -2,6 +2,7 @@ import type { IntentOptionDefinition } from '../intentRuntime.ts'
 import type { SemanticIntentDescriptor, SemanticIntentPresentation } from './index.ts'
 import { parseOptionalEnumValue } from './parsing.ts'
 
+const defaultImageGenerateModel = 'google/nano-banana-2'
 const imageGenerateFormats = ['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg'] as const
 
 const imageGenerateOptionDefinitions = [
@@ -19,8 +20,9 @@ const imageGenerateOptionDefinitions = [
     kind: 'string',
     propertyName: 'model',
     optionFlags: '--model',
-    description: 'The AI model to use for image generation.',
+    description: `The AI model to use for image generation. Defaults to ${defaultImageGenerateModel}.`,
     required: false,
+    exampleValue: defaultImageGenerateModel,
   },
   {
     name: 'format',
@@ -154,6 +156,7 @@ function createImageGenerateStep(
   const step: Record<string, unknown> = {
     robot: '/image/generate',
     result: true,
+    model: defaultImageGenerateModel,
     prompt: parseRequiredPrompt(rawValues.prompt),
   }
 

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -11,7 +11,7 @@ const imageGenerateOptionDefinitions = [
     propertyName: 'prompt',
     optionFlags: '--prompt',
     description: 'The prompt describing the desired image content.',
-    required: false,
+    required: true,
     exampleValue: JSON.stringify('A red bicycle in a studio'),
   },
   {
@@ -122,9 +122,26 @@ function parseOptionalNumber(flagName: string, value: unknown): number | undefin
     return undefined
   }
 
-  const numericValue = typeof value === 'number' ? value : Number.parseFloat(String(value).trim())
+  const numericValue = typeof value === 'number' ? value : Number(String(value).trim())
   if (Number.isNaN(numericValue)) {
     throw new Error(`${flagName} must be a number`)
+  }
+
+  return numericValue
+}
+
+function parseOptionalIntegerRange(
+  flagName: string,
+  value: unknown,
+  { max, min }: { max: number; min: number },
+): number | undefined {
+  const numericValue = parseOptionalNumber(flagName, value)
+  if (numericValue == null) {
+    return undefined
+  }
+
+  if (!Number.isInteger(numericValue) || numericValue < min || numericValue > max) {
+    throw new Error(`${flagName} must be an integer between ${min} and ${max}`)
   }
 
   return numericValue
@@ -182,7 +199,10 @@ function createImageGenerateStep(
     step.style = style
   }
 
-  const numOutputs = parseOptionalNumber('--num-outputs', rawValues.numOutputs)
+  const numOutputs = parseOptionalIntegerRange('--num-outputs', rawValues.numOutputs, {
+    min: 1,
+    max: 10,
+  })
   if (numOutputs != null) {
     step.num_outputs = numOutputs
   }

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -1,4 +1,5 @@
-import type { IntentOptionDefinition } from '../intentRuntime.ts'
+import { basename } from 'node:path'
+import type { IntentOptionDefinition, PreparedIntentInputs } from '../intentRuntime.ts'
 import type { SemanticIntentDescriptor, SemanticIntentPresentation } from './index.ts'
 import { parseOptionalEnumValue } from './parsing.ts'
 
@@ -213,6 +214,24 @@ function createImageGenerateStep(
   return step
 }
 
+function ensureUniqueInputBasenames(preparedInputs: PreparedIntentInputs): PreparedIntentInputs {
+  const seenBasenames = new Map<string, string>()
+
+  for (const input of preparedInputs.inputs) {
+    const inputBasename = basename(input)
+    const previousInput = seenBasenames.get(inputBasename)
+    if (previousInput != null) {
+      throw new Error(
+        `image generate requires unique input basenames when prompts refer to files; found duplicate ${inputBasename} in ${previousInput} and ${input}`,
+      )
+    }
+
+    seenBasenames.set(inputBasename, input)
+  }
+
+  return preparedInputs
+}
+
 export const imageGenerateSemanticIntentDescriptor = {
   createStep: createImageGenerateStep,
   execution: {
@@ -227,6 +246,9 @@ export const imageGenerateSemanticIntentDescriptor = {
     attachUseWhenInputsProvided: false,
   },
   outputDescription: 'Write the result to this path',
+  async prepareInputs(preparedInputs) {
+    return await Promise.resolve(ensureUniqueInputBasenames(preparedInputs))
+  },
   presentation: imageGenerateCommandPresentation,
   runnerKind: 'bundled',
 } as const satisfies SemanticIntentDescriptor

--- a/packages/node/src/cli/semanticIntents/index.ts
+++ b/packages/node/src/cli/semanticIntents/index.ts
@@ -5,6 +5,7 @@ import type {
   PreparedIntentInputs,
 } from '../intentRuntime.ts'
 import { imageDescribeSemanticIntentDescriptor } from './imageDescribe.ts'
+import { imageGenerateSemanticIntentDescriptor } from './imageGenerate.ts'
 import {
   markdownDocxSemanticIntentDescriptor,
   markdownPdfSemanticIntentDescriptor,
@@ -17,7 +18,10 @@ export interface SemanticIntentPresentation {
 }
 
 export interface SemanticIntentDescriptor {
-  createStep: (rawValues: Record<string, unknown>) => Record<string, unknown>
+  createStep: (
+    rawValues: Record<string, unknown>,
+    context: { hasInputs: boolean },
+  ) => Record<string, unknown>
   execution: IntentDynamicStepExecutionDefinition
   inputPolicy: IntentInputPolicy
   outputDescription: string
@@ -31,6 +35,7 @@ export interface SemanticIntentDescriptor {
 
 const semanticIntentDescriptors: Record<string, SemanticIntentDescriptor> = {
   'image-describe': imageDescribeSemanticIntentDescriptor,
+  'image-generate': imageGenerateSemanticIntentDescriptor,
   'markdown-pdf': {
     ...markdownPdfSemanticIntentDescriptor,
   },

--- a/packages/node/src/cli/semanticIntents/markdownPdf.ts
+++ b/packages/node/src/cli/semanticIntents/markdownPdf.ts
@@ -76,7 +76,7 @@ function createMarkdownConvertSemanticIntent({
   } satisfies SemanticIntentPresentation
 
   return {
-    createStep(rawValues) {
+    createStep(rawValues, _context) {
       return {
         robot: '/document/convert',
         use: ':original',

--- a/packages/node/test/e2e/cli/assemblies-create.test.ts
+++ b/packages/node/test/e2e/cli/assemblies-create.test.ts
@@ -471,7 +471,7 @@ describeLive('assemblies', () => {
           'Max concurrent jobs should not exceed concurrency limit',
         ).to.be.at.most(2)
       }),
-      180_000,
+      300_000,
     )
 
     it(
@@ -507,7 +507,7 @@ describeLive('assemblies', () => {
         expect(streamClosedMessages).to.have.lengthOf(0)
         expect(messages).to.include(`Creating single assembly with ${fileCount} files`)
       }),
-      180_000,
+      300_000,
     )
   })
 })

--- a/packages/node/test/e2e/cli/assemblies-create.test.ts
+++ b/packages/node/test/e2e/cli/assemblies-create.test.ts
@@ -179,6 +179,7 @@ describeLive('assemblies', () => {
         expect(outs).to.include('out/sub/3.jpg')
         expect(outs).to.have.lengthOf(3)
       }),
+      180_000,
     )
 
     it(
@@ -336,6 +337,7 @@ describeLive('assemblies', () => {
         expect(dim.width).to.be.greaterThan(0)
         expect(dim.height).to.be.greaterThan(0)
       }),
+      180_000,
     )
 
     it(
@@ -361,6 +363,7 @@ describeLive('assemblies', () => {
         expect(hasM3u8).to.equal(true)
         expect(hasTs).to.equal(true)
       }),
+      180_000,
     )
 
     it(
@@ -504,6 +507,7 @@ describeLive('assemblies', () => {
         expect(streamClosedMessages).to.have.lengthOf(0)
         expect(messages).to.include(`Creating single assembly with ${fileCount} files`)
       }),
+      180_000,
     )
   })
 })

--- a/packages/node/test/support/intentSmokeCases.ts
+++ b/packages/node/test/support/intentSmokeCases.ts
@@ -59,12 +59,7 @@ const intentSmokeOverrides: Record<string, Omit<IntentSmokeCase, 'key' | 'paths'
     verifier: 'png',
   },
   'image-generate:image/generate': {
-    args: [
-      '--prompt',
-      'A small red bicycle on a cream background, studio lighting',
-      '--model',
-      'google/nano-banana',
-    ],
+    args: ['--prompt', 'A small red bicycle on a cream background, studio lighting'],
     outputPath: 'image-generate.png',
     verifier: 'png',
   },

--- a/packages/node/test/support/intentSmokeCases.ts
+++ b/packages/node/test/support/intentSmokeCases.ts
@@ -58,7 +58,7 @@ const intentSmokeOverrides: Record<string, Omit<IntentSmokeCase, 'key' | 'paths'
     outputPath: 'image-remove-background.png',
     verifier: 'png',
   },
-  '/image/generate': {
+  'image-generate:image/generate': {
     args: [
       '--prompt',
       'A small red bicycle on a cream background, studio lighting',

--- a/packages/node/test/unit/cli/intent-docs.test.ts
+++ b/packages/node/test/unit/cli/intent-docs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { renderIntentDocsBody } from '../../../src/cli/generateIntentDocs.ts'
+import { resolveIntentCommandDefinitions } from '../../../src/cli/intentCommands.ts'
+
+describe('intent docs generation', () => {
+  it('renders image generate usage without implying required input files', () => {
+    const markdown = renderIntentDocsBody({
+      definitions: resolveIntentCommandDefinitions(),
+      headingLevel: 2,
+    })
+
+    expect(markdown).toContain(
+      'npx transloadit image generate [--input <path|dir|url|->] [options]',
+    )
+    expect(markdown).not.toContain(
+      'npx transloadit image generate --input <path|dir|url|-> [options]',
+    )
+  })
+
+  it('includes the multi-input image generate example', () => {
+    const markdown = renderIntentDocsBody({
+      definitions: resolveIntentCommandDefinitions(),
+      headingLevel: 2,
+    })
+
+    expect(markdown).toContain(
+      'transloadit image generate --input person1.jpg --input person2.jpg --input background.jpg --prompt "Place person1.jpg feeding person2.jpg in front of background.jpg" --out output.png',
+    )
+  })
+})

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -325,6 +325,33 @@ describe('intent commands', () => {
     )
   })
 
+  it('defaults image generate to google/nano-banana-2 when no --model is provided', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--prompt',
+      'A red bicycle in a studio',
+      '--out',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.any(OutputCtl),
+      expect.anything(),
+      expect.objectContaining({
+        stepsData: {
+          generate: expect.objectContaining({
+            robot: '/image/generate',
+            model: 'google/nano-banana-2',
+            prompt: 'A red bicycle in a studio',
+            result: true,
+          }),
+        },
+      }),
+    )
+  })
+
   it('bundles image generate inputs into a single /image/generate step', async () => {
     const { createSpy } = await runIntentCommand([
       'image',

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -313,7 +313,7 @@ describe('intent commands', () => {
         inputs: [],
         output: 'generated.png',
         stepsData: {
-          [getIntentStepName(['image', 'generate'])]: expect.objectContaining({
+          generate: expect.objectContaining({
             robot: '/image/generate',
             result: true,
             prompt: 'A red bicycle in a studio',
@@ -323,6 +323,59 @@ describe('intent commands', () => {
         },
       }),
     )
+  })
+
+  it('bundles image generate inputs into a single /image/generate step', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--input',
+      'person1.jpg',
+      '--input',
+      'person2.jpg',
+      '--input',
+      'background.jpg',
+      '--prompt',
+      'Place person1.jpg feeding person2.jpg in front of background.jpg',
+      '--out',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.any(OutputCtl),
+      expect.anything(),
+      expect.objectContaining({
+        inputs: ['person1.jpg', 'person2.jpg', 'background.jpg'],
+        output: 'generated.png',
+        singleAssembly: true,
+        stepsData: {
+          generate: expect.objectContaining({
+            robot: '/image/generate',
+            result: true,
+            prompt: 'Place person1.jpg feeding person2.jpg in front of background.jpg',
+            use: {
+              steps: [':original'],
+              bundle_steps: true,
+            },
+          }),
+        },
+      }),
+    )
+  })
+
+  it('requires --prompt for image generate even when inputs are provided', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--input',
+      'person1.jpg',
+      '--out',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBe(1)
+    expect(createSpy).not.toHaveBeenCalled()
   })
 
   it('maps preview generate flags to /file/preview step parameters', async () => {

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -435,6 +435,24 @@ describe('intent commands', () => {
     expect(createSpy).not.toHaveBeenCalled()
   })
 
+  it('rejects duplicate image generate input basenames', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--input',
+      'dir-a/person.jpg',
+      '--input',
+      'dir-b/person.jpg',
+      '--prompt',
+      'Place person.jpg into a magazine cover',
+      '--out',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBe(1)
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
   it('maps preview generate flags to /file/preview step parameters', async () => {
     const { createSpy } = await runIntentCommand([
       'preview',

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -18,7 +18,7 @@ import {
   inferIntentFieldKind,
   parseStringArrayValue,
 } from '../../../src/cli/intentFields.ts'
-import { prepareIntentInputs } from '../../../src/cli/intentRuntime.ts'
+import { getIntentOptionDefinitions, prepareIntentInputs } from '../../../src/cli/intentRuntime.ts'
 import OutputCtl from '../../../src/cli/OutputCtl.ts'
 import { main } from '../../../src/cli.ts'
 import { intentSmokeCases } from '../../support/intentSmokeCases.ts'
@@ -370,6 +370,36 @@ describe('intent commands', () => {
       'generate',
       '--input',
       'person1.jpg',
+      '--out',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBe(1)
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+
+  it('marks --prompt as required in image generate option metadata', () => {
+    const command = getIntentCommand(['image', 'generate'])
+    const intentDefinition = Reflect.get(command, 'intentDefinition')
+    if (intentDefinition == null || typeof intentDefinition !== 'object') {
+      throw new Error('Missing intent definition')
+    }
+
+    const promptField = getIntentOptionDefinitions(
+      intentDefinition as Parameters<typeof getIntentOptionDefinitions>[0],
+    ).find((field) => field.name === 'prompt')
+
+    expect(promptField?.required).toBe(true)
+  })
+
+  it('rejects invalid --num-outputs values for image generate before creating an assembly', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--prompt',
+      'A red bicycle in a studio',
+      '--num-outputs',
+      '11',
       '--out',
       'generated.png',
     ])


### PR DESCRIPTION
## Summary
- let `image generate` accept repeated `--input` values while keeping prompt-only text-to-image working
- bundle provided inputs into a single `/image/generate` assembly so prompts can refer to files by name
- restore local prompt and `--num-outputs` validation, with regression coverage

## Testing
- yarn check
- ~/code/dotfiles/bin/council.ts review
- yarn vitest run packages/node/test/unit/cli/intents.test.ts