### PR TITLE
fix: sync lockfile after version packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: corepack yarn tsc:zod
       - uses: changesets/action@v1
         with:
-          version: corepack yarn changeset version
+          version: corepack yarn changeset version && corepack yarn
           publish: corepack yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,7 +2525,7 @@ __metadata:
   resolution: "@transloadit/mcp-server@workspace:packages/mcp-server"
   dependencies:
     "@modelcontextprotocol/sdk": "npm:^1.25.3"
-    "@transloadit/node": "npm:^4.8.0"
+    "@transloadit/node": "npm:^4.8.1"
     "@transloadit/sev-logger": "npm:^0.1.9"
     "@types/express": "npm:^4.17.23"
     "@types/node": "npm:^24.10.3"
@@ -2537,7 +2537,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@transloadit/node@npm:^4.8.0, @transloadit/node@workspace:packages/node":
+"@transloadit/node@npm:^4.8.1, @transloadit/node@workspace:packages/node":
   version: 0.0.0-use.local
   resolution: "@transloadit/node@workspace:packages/node"
   dependencies:


### PR DESCRIPTION
## Summary
- update `yarn.lock` after the merged Version Packages PR bumped `@transloadit/node` from `^4.8.0` to `^4.8.1` in `packages/mcp-server/package.json`
- make the Changesets `Version Packages` workflow run `corepack yarn` after `changeset version` so future release PRs include the lockfile update automatically

## Verification
- `corepack yarn check`
