### PR TITLE
fix: release transloadit alongside node

### DIFF
--- a/.changeset/shaggy-peas-march.md
+++ b/.changeset/shaggy-peas-march.md
@@ -1,0 +1,5 @@
+---
+'transloadit': patch
+---
+
+Publish the generated `transloadit` package with the home-credentials CLI support that already shipped in `@transloadit/node`.

--- a/packages/node/test/unit/cli/auth-token.test.ts
+++ b/packages/node/test/unit/cli/auth-token.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { main } from '../../../src/cli.ts'
 
@@ -258,10 +261,18 @@ describe('cli auth token', () => {
   })
 
   it('fails when credentials are missing', async () => {
+    const emptyCredentialsFile = path.join(
+      mkdtempSync(path.join(tmpdir(), 'transloadit-auth-token-')),
+      'credentials',
+    )
+    writeFileSync(emptyCredentialsFile, '')
+
     vi.stubEnv('TRANSLOADIT_KEY', '')
     vi.stubEnv('TRANSLOADIT_SECRET', '')
     vi.stubEnv('TRANSLOADIT_AUTH_KEY', '')
     vi.stubEnv('TRANSLOADIT_AUTH_SECRET', '')
+    vi.stubEnv('TRANSLOADIT_AUTH_TOKEN', '')
+    vi.stubEnv('TRANSLOADIT_CREDENTIALS_FILE', emptyCredentialsFile)
 
     const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 

--- a/scripts/guard-changesets.ts
+++ b/scripts/guard-changesets.ts
@@ -11,6 +11,7 @@ type ParsedChangeset = {
 const CHANGESET_DIR = path.join(process.cwd(), '.changeset')
 const NODE_PKG = '@transloadit/node'
 const MCP_SERVER_PKG = '@transloadit/mcp-server'
+const TRANSLOADIT_PKG = 'transloadit'
 
 async function listChangesetFiles(): Promise<string[]> {
   let entries: string[]
@@ -74,11 +75,12 @@ async function main(): Promise<void> {
     for (const pkg of cs.packages) touched.add(pkg)
   }
 
-  // One-way coupling policy:
+  // Coupling policy:
   // If @transloadit/node is being released, also release @transloadit/mcp-server
-  // so the published mcp-server versions stay "in sync" with node evolution.
+  // and the published transloadit clone so all three stay in sync.
   const touchesNode = touched.has(NODE_PKG)
   const touchesMcpServer = touched.has(MCP_SERVER_PKG)
+  const touchesTransloadit = touched.has(TRANSLOADIT_PKG)
 
   if (touchesNode && !touchesMcpServer) {
     fail(
@@ -92,6 +94,22 @@ async function main(): Promise<void> {
         '  corepack yarn changeset',
         `  (select ${MCP_SERVER_PKG} -> patch)`,
         `  Summary: "chore: release mcp-server alongside @transloadit/node"`,
+      ].join('\n'),
+    )
+  }
+
+  if (touchesNode && !touchesTransloadit) {
+    fail(
+      [
+        `Changeset policy violation: ${NODE_PKG} is being released, but ${TRANSLOADIT_PKG} is not.`,
+        '',
+        `Add a patch changeset for ${TRANSLOADIT_PKG} so npx users get the same CLI behavior as`,
+        `${NODE_PKG} users, including the generated transloadit package clone.`,
+        '',
+        'Example:',
+        '  corepack yarn changeset',
+        `  (select ${TRANSLOADIT_PKG} -> patch)`,
+        `  Summary: "chore: release transloadit alongside @transloadit/node"`,
       ].join('\n'),
     )
   }


### PR DESCRIPTION
## Summary
- release the `transloadit` package with the home-credentials CLI support already shipped in `@transloadit/node`
- enforce that future `@transloadit/node` changesets also include `transloadit` so npm `npx transloadit@latest` does not lag behind again
- make the auth-token missing-credentials test deterministic on machines that have `~/.transloadit/credentials`

## Verification
- `corepack yarn check`
