### PR TITLE
fix: run changeset version via yarn script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - run: corepack yarn tsc:zod
       - uses: changesets/action@v1
         with:
-          version: corepack yarn changeset version && corepack yarn
+          version: corepack yarn changeset:version:release
           publish: corepack yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "yarn lint:changesets && yarn fix:deps && yarn fix:js && yarn lint:ts && yarn test:unit",
     "verify": "yarn lint:changesets && yarn lint:publish && yarn lint:deps && yarn lint:js && yarn lint:ts && yarn test:unit",
     "verify:full": "yarn verify && yarn knip && yarn parity:transloadit && yarn test:types",
+    "changeset:version:release": "yarn changeset version && yarn",
     "lint:js": "biome check .",
     "lint:ts": "yarn tsc:types && yarn tsc:node && yarn tsc:zod && yarn workspace @transloadit/notify-url-relay lint:ts",
     "lint:changesets": "node scripts/guard-changesets.ts",

--- a/packages/node/test/unit/cli/auth-token.test.ts
+++ b/packages/node/test/unit/cli/auth-token.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { main } from '../../../src/cli.ts'
 
@@ -258,10 +261,18 @@ describe('cli auth token', () => {
   })
 
   it('fails when credentials are missing', async () => {
+    const emptyCredentialsFile = path.join(
+      mkdtempSync(path.join(tmpdir(), 'transloadit-auth-token-')),
+      'credentials',
+    )
+    writeFileSync(emptyCredentialsFile, '')
+
     vi.stubEnv('TRANSLOADIT_KEY', '')
     vi.stubEnv('TRANSLOADIT_SECRET', '')
     vi.stubEnv('TRANSLOADIT_AUTH_KEY', '')
     vi.stubEnv('TRANSLOADIT_AUTH_SECRET', '')
+    vi.stubEnv('TRANSLOADIT_AUTH_TOKEN', '')
+    vi.stubEnv('TRANSLOADIT_CREDENTIALS_FILE', emptyCredentialsFile)
 
     const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 


### PR DESCRIPTION
## Summary
- fix the release workflow so `changesets/action` runs the version step through a dedicated Yarn script instead of a shell-style `&&` command that it cannot parse
- include the auth-token missing-credentials test fix so `yarn check` stays deterministic on machines with `~/.transloadit/credentials`
- unblock the pending `transloadit` release created by `#378`

## Verification
- `corepack yarn check`
