### PR TITLE
fix: preserve transloadit wrapper version during release prep

### DIFF
--- a/docs/prompts/2026-04-14-sync-transloadit-package-version.md
+++ b/docs/prompts/2026-04-14-sync-transloadit-package-version.md
@@ -1,0 +1,6 @@
+# PR 381 Todo
+
+- [x] Confirm the drift: `packages/transloadit/package.json` claimed `4.8.2` while npm only had `transloadit@4.8.1`
+- [x] Restore `packages/transloadit/package.json` to `4.8.1`
+- [x] Run `corepack yarn check`
+- [x] Verify there are no open PR review comments to address

--- a/packages/node/test/unit/prepare-transloadit.test.ts
+++ b/packages/node/test/unit/prepare-transloadit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildLegacyPackageJson } from '../../../../scripts/prepare-transloadit.ts'
+
+describe('prepare-transloadit', () => {
+  it('preserves an existing transloadit-only version bump', () => {
+    const nodePackageJson = {
+      name: '@transloadit/node',
+      version: '4.8.1',
+      scripts: {
+        check: 'yarn lint && yarn fix',
+        'test:unit': 'vitest run --coverage ./test/unit',
+        'test:e2e': 'vitest run ./test/e2e',
+        test: 'vitest run --coverage',
+      },
+      devDependencies: {
+        vitest: '^3.2.4',
+      },
+      bin: {
+        transloadit: './dist/cli.js',
+      },
+      publishConfig: {
+        tag: 'experimental',
+      },
+    }
+
+    const legacyExisting = {
+      name: 'transloadit',
+      version: '4.8.2',
+      devDependencies: {
+        vitest: '^3.2.4',
+      },
+    }
+
+    const legacyPackageJson = buildLegacyPackageJson(nodePackageJson, legacyExisting)
+
+    expect(legacyPackageJson.name).toBe('transloadit')
+    expect(legacyPackageJson.version).toBe('4.8.2')
+    expect(legacyPackageJson.bin).toBe('./dist/cli.js')
+    expect(legacyPackageJson.publishConfig).toBeUndefined()
+  })
+
+  it('falls back to the node package version when no legacy package exists yet', () => {
+    const nodePackageJson = {
+      name: '@transloadit/node',
+      version: '4.8.1',
+      scripts: {},
+      devDependencies: {},
+    }
+
+    const legacyPackageJson = buildLegacyPackageJson(nodePackageJson, null)
+
+    expect(legacyPackageJson.version).toBe('4.8.1')
+  })
+})

--- a/packages/transloadit/package.json
+++ b/packages/transloadit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transloadit",
-  "version": "4.8.2",
+  "version": "4.8.1",
   "description": "Node.js SDK for Transloadit",
   "homepage": "https://github.com/transloadit/node-sdk/tree/main/packages/node",
   "bugs": {

--- a/scripts/prepare-transloadit.ts
+++ b/scripts/prepare-transloadit.ts
@@ -78,15 +78,17 @@ function deriveLegacyScripts(nodeScripts: Record<string, string>): Record<string
   return scripts
 }
 
-const writeLegacyPackageJson = async (): Promise<void> => {
-  const nodePackageJson = await readJson<PackageJson>(resolve(nodePackage, 'package.json'))
-  const legacyExisting = await readJson<PackageJson>(resolve(legacyPackage, 'package.json')).catch(
-    () => null,
-  )
+function buildLegacyPackageJson(
+  nodePackageJson: PackageJson,
+  legacyExisting: PackageJson | null,
+): PackageJson {
   const scripts = deriveLegacyScripts(nodePackageJson.scripts ?? {})
+  const legacyVersion =
+    typeof legacyExisting?.version === 'string' ? legacyExisting.version : nodePackageJson.version
   const legacyPackageJson: PackageJson = {
     ...nodePackageJson,
     name: 'transloadit',
+    version: legacyVersion,
     scripts,
     devDependencies: legacyExisting?.devDependencies ?? nodePackageJson.devDependencies,
   }
@@ -103,6 +105,16 @@ const writeLegacyPackageJson = async (): Promise<void> => {
   ) {
     legacyPackageJson.bin = legacyBin.transloadit as string
   }
+
+  return legacyPackageJson
+}
+
+const writeLegacyPackageJson = async (): Promise<void> => {
+  const nodePackageJson = await readJson<PackageJson>(resolve(nodePackage, 'package.json'))
+  const legacyExisting = await readJson<PackageJson>(resolve(legacyPackage, 'package.json')).catch(
+    () => null,
+  )
+  const legacyPackageJson = buildLegacyPackageJson(nodePackageJson, legacyExisting)
 
   const formatted = formatPackageJson(legacyPackageJson)
   await writeFile(resolve(legacyPackage, 'package.json'), formatted)
@@ -128,4 +140,8 @@ const main = async (): Promise<void> => {
   await writeLegacyChangelog()
 }
 
-await main()
+if (process.argv[1] != null && resolve(process.argv[1]) === filePath) {
+  await main()
+}
+
+export { buildLegacyPackageJson, deriveLegacyScripts }


### PR DESCRIPTION
## Summary
- sync `packages/transloadit/package.json` back to the version actually published on npm
- preserve existing `transloadit` version bumps in `scripts/prepare-transloadit.ts` so transloadit-only releases survive prepack instead of being rewritten back to `@transloadit/node`
- add a unit test that locks this transloadit-only release behavior in place

## Verification
- `corepack yarn check`
