### PR TITLE
fix: allow release lockfile updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "check": "yarn lint:changesets && yarn fix:deps && yarn fix:js && yarn lint:ts && yarn test:unit",
     "verify": "yarn lint:changesets && yarn lint:publish && yarn lint:deps && yarn lint:js && yarn lint:ts && yarn lint:transloadit-sync && yarn test:unit",
     "verify:full": "yarn verify && yarn knip && yarn test:types",
-    "changeset:version:release": "yarn changeset version && yarn",
+    "changeset:version:release": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install",
     "lint:js": "biome check .",
     "lint:ts": "yarn tsc:types && yarn tsc:node && yarn tsc:zod && yarn workspace @transloadit/notify-url-relay lint:ts",
     "lint:transloadit-sync": "node scripts/check-transloadit-sync.ts",


### PR DESCRIPTION
## Summary
- allow the release-only changesets install step to update yarn.lock after version bumps
- keep immutable installs everywhere else
- avoid the recurring YN0028 failure on main release runs

## Validation
- reproduced the failing path in a disposable worktree with a temporary changeset that bumped @transloadit/node and @transloadit/mcp-server
- ran `corepack yarn changeset:version:release` successfully and confirmed it updated `yarn.lock` instead of failing with YN0028