### PR TITLE
fix: avoid node publish race during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - run: corepack yarn
       - run: corepack yarn tsc:utils
       - run: corepack yarn tsc:zod
+      - run: corepack yarn tsc:node
       - uses: changesets/action@v1
         with:
           version: corepack yarn changeset:version:release
@@ -33,3 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"
+          TRANSLOADIT_PUBLISH_PREBUILT_NODE: "true"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -90,7 +90,7 @@
     "fix": "yarn fix:js",
     "lint:deps": "knip --dependencies --no-progress",
     "fix:deps": "knip --dependencies --no-progress --fix",
-    "prepack": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && rm -f tsconfig.tsbuildinfo tsconfig.build.tsbuildinfo && yarn --cwd ../.. tsc:node && chmod +x dist/cli.js",
+    "prepack": "node ../../scripts/prepare-node-package.ts",
     "test:unit": "yarn --cwd ../.. tsc:utils && ../../node_modules/.bin/vitest run --coverage ./test/unit",
     "test:e2e": "yarn --cwd ../.. tsc:utils && ../../node_modules/.bin/vitest run ./test/e2e",
     "test": "yarn --cwd ../.. tsc:utils && ../../node_modules/.bin/vitest run --coverage"

--- a/packages/node/test/unit/prepare-transloadit.test.ts
+++ b/packages/node/test/unit/prepare-transloadit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { shouldReusePreparedNodeDist } from '../../../../scripts/prepare-node-package.ts'
 import { buildLegacyPackageJson } from '../../../../scripts/prepare-transloadit.ts'
 
 describe('prepare-transloadit', () => {
@@ -51,5 +52,25 @@ describe('prepare-transloadit', () => {
     const legacyPackageJson = buildLegacyPackageJson(nodePackageJson, null)
 
     expect(legacyPackageJson.version).toBe('4.8.1')
+  })
+
+  it('only reuses a prepared node dist during the explicit publish flow', () => {
+    const original = process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE
+
+    try {
+      expect(shouldReusePreparedNodeDist(false)).toBe(false)
+
+      process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE = 'true'
+      expect(shouldReusePreparedNodeDist(true)).toBe(true)
+
+      delete process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE
+      expect(shouldReusePreparedNodeDist(true)).toBe(false)
+    } finally {
+      if (original == null) {
+        delete process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE
+      } else {
+        process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE = original
+      }
+    }
   })
 })

--- a/scripts/prepare-node-package.ts
+++ b/scripts/prepare-node-package.ts
@@ -1,0 +1,41 @@
+import { execFile } from 'node:child_process'
+import { access, chmod, rm } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const filePath = fileURLToPath(import.meta.url)
+const repoRoot = resolve(dirname(filePath), '..')
+const nodePackage = resolve(repoRoot, 'packages/node')
+const nodeDistCli = resolve(nodePackage, 'dist/cli.js')
+
+function shouldReusePreparedNodeDist(hasNodeDist: boolean): boolean {
+  return process.env.TRANSLOADIT_PUBLISH_PREBUILT_NODE === 'true' && hasNodeDist
+}
+
+const ensureNodePackagePrepared = async (): Promise<void> => {
+  const hasNodeDist = await access(nodeDistCli)
+    .then(() => true)
+    .catch(() => false)
+
+  if (shouldReusePreparedNodeDist(hasNodeDist)) {
+    await chmod(nodeDistCli, 0o755)
+    return
+  }
+
+  await rm(resolve(nodePackage, 'dist'), { recursive: true, force: true })
+  await rm(resolve(nodePackage, 'tsconfig.tsbuildinfo'), { force: true })
+  await rm(resolve(nodePackage, 'tsconfig.build.tsbuildinfo'), { force: true })
+  await execFileAsync('yarn', ['tsc:node'], {
+    cwd: repoRoot,
+  })
+  await chmod(nodeDistCli, 0o755)
+}
+
+if (process.argv[1] != null && resolve(process.argv[1]) === filePath) {
+  await ensureNodePackagePrepared()
+}
+
+export { ensureNodePackagePrepared, shouldReusePreparedNodeDist }

--- a/scripts/prepare-transloadit.ts
+++ b/scripts/prepare-transloadit.ts
@@ -1,10 +1,7 @@
-import { execFile } from 'node:child_process'
 import { chmod, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { promisify } from 'node:util'
-
-const execFileAsync = promisify(execFile)
+import { ensureNodePackagePrepared } from './prepare-node-package.ts'
 
 const filePath = fileURLToPath(import.meta.url)
 const repoRoot = resolve(dirname(filePath), '..')
@@ -127,9 +124,7 @@ const writeLegacyChangelog = async (): Promise<void> => {
 }
 
 const main = async (): Promise<void> => {
-  await execFileAsync('yarn', ['workspace', '@transloadit/node', 'prepack'], {
-    cwd: repoRoot,
-  })
+  await ensureNodePackagePrepared()
 
   await copyDir(resolve(nodePackage, 'dist'), resolve(legacyPackage, 'dist'))
   await copyDir(resolve(nodePackage, 'src'), resolve(legacyPackage, 'src'))


### PR DESCRIPTION
## Summary
- reuse a prebuilt `@transloadit/node` dist during the release publish flow instead of rebuilding it concurrently
- prebuild `@transloadit/node` in the release workflow and pass an explicit env flag to publish-time prep
- keep local prepack behavior rebuilding by default outside the release flow

## Validation
- `corepack yarn exec vitest run packages/node/test/unit/prepare-transloadit.test.ts`
- concurrent local pack simulation for `@transloadit/node` and `transloadit` with `TRANSLOADIT_PUBLISH_PREBUILT_NODE=true`
- `corepack yarn check` in a clean worktree