### PR TITLE
chore: add a PR release dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,26 @@ jobs:
       - run: corepack yarn
       - run: corepack yarn verify:full
 
+  release-dry-run:
+    name: Release dry run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm install -g npm@11.5.1
+      - run: corepack yarn
+      - run: corepack yarn tsc:utils
+      - run: corepack yarn tsc:zod
+      - run: corepack yarn tsc:node
+      - run: corepack yarn changeset:version:release
+      - run: corepack yarn release:pack:dry-run
+
   unit:
     name: Unit tests (Node ${{ matrix.node }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "verify": "yarn lint:changesets && yarn lint:publish && yarn lint:deps && yarn lint:js && yarn lint:ts && yarn lint:transloadit-sync && yarn test:unit",
     "verify:full": "yarn verify && yarn knip && yarn test:types",
     "changeset:version:release": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install",
+    "release:pack:dry-run": "node scripts/release-dry-run.ts",
     "lint:js": "biome check .",
     "lint:ts": "yarn tsc:types && yarn tsc:node && yarn tsc:zod && yarn workspace @transloadit/notify-url-relay lint:ts",
     "lint:transloadit-sync": "node scripts/check-transloadit-sync.ts",

--- a/scripts/release-dry-run.ts
+++ b/scripts/release-dry-run.ts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const filePath = fileURLToPath(import.meta.url)
+const repoRoot = resolve(dirname(filePath), '..')
+
+type PackTarget = {
+  packagePath: string
+  extraEnv?: NodeJS.ProcessEnv
+}
+
+async function packPackage(packDir: string, target: PackTarget): Promise<void> {
+  await execFileAsync('npm', ['pack', target.packagePath, '--pack-destination', packDir], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...target.extraEnv,
+    },
+  })
+}
+
+const main = async (): Promise<void> => {
+  const packDir = await mkdtemp(resolve(tmpdir(), 'transloadit-release-dry-run-'))
+
+  await Promise.all([
+    packPackage(packDir, {
+      packagePath: './packages/node',
+      extraEnv: { TRANSLOADIT_PUBLISH_PREBUILT_NODE: 'true' },
+    }),
+    packPackage(packDir, {
+      packagePath: './packages/transloadit',
+      extraEnv: { TRANSLOADIT_PUBLISH_PREBUILT_NODE: 'true' },
+    }),
+  ])
+
+  await packPackage(packDir, {
+    packagePath: './packages/mcp-server',
+  })
+}
+
+if (process.argv[1] != null && resolve(process.argv[1]) === filePath) {
+  await main()
+}
+
+export { packPackage }


### PR DESCRIPTION
## Summary
- add a PR-only CI job that mirrors the release workflow setup
- run `changeset:version:release` in CI before publish to catch versioning and lockfile issues pre-merge
- exercise publish prep without publishing by packing `@transloadit/node` and `transloadit` concurrently plus `@transloadit/mcp-server`

## Validation
- `corepack yarn exec biome check .github/workflows/ci.yml package.json scripts/release-dry-run.ts`
- `corepack yarn tsc:zod && corepack yarn tsc:node && corepack yarn changeset:version:release && corepack yarn release:pack:dry-run`
- `corepack yarn check` in a clean worktree