### PR TITLE
Include Assembly URL in create errors

### DIFF
--- a/.changeset/tiny-knives-juggle.md
+++ b/.changeset/tiny-knives-juggle.md
@@ -1,0 +1,8 @@
+---
+'@transloadit/node': patch
+'@transloadit/mcp-server': patch
+'transloadit': patch
+---
+
+Improve `assemblies create` timeout diagnostics by including the assembly URL when available and
+stabilize the CLI watch-mode test coverage around concurrent assembly updates.

--- a/packages/node/src/cli/commands/assemblies.ts
+++ b/packages/node/src/cli/commands/assemblies.ts
@@ -1403,12 +1403,7 @@ export async function create(
       const result = await client.createAssembly(createOptions)
       const assemblyId = result.assembly_id
       if (!assemblyId) throw new Error('No assembly_id in result')
-      const assemblyUrl =
-        result.assembly_ssl_url ??
-        result.assembly_url ??
-        ('getLastUsedAssemblyUrl' in client && typeof client.getLastUsedAssemblyUrl === 'function'
-          ? client.getLastUsedAssemblyUrl()
-          : null)
+      const assemblyUrl = result.assembly_ssl_url ?? result.assembly_url ?? null
       const assemblyReference = formatAssemblyReference({ assemblyId, assemblyUrl })
 
       let assembly: Awaited<ReturnType<typeof client.awaitAssemblyCompletion>>

--- a/packages/node/src/cli/commands/assemblies.ts
+++ b/packages/node/src/cli/commands/assemblies.ts
@@ -78,6 +78,20 @@ export interface AssemblyLintOptions {
   json?: boolean
 }
 
+function formatAssemblyReference({
+  assemblyId,
+  assemblyUrl,
+}: {
+  assemblyId: string
+  assemblyUrl: string | null
+}): string {
+  if (assemblyUrl != null) {
+    return `Assembly ID: ${assemblyId}, Assembly URL: ${assemblyUrl}`
+  }
+
+  return `Assembly ID: ${assemblyId}`
+}
+
 function parseTemplateFieldAssignments(
   output: IOutputCtl,
   fields: string[] | undefined,
@@ -1389,18 +1403,30 @@ export async function create(
       const result = await client.createAssembly(createOptions)
       const assemblyId = result.assembly_id
       if (!assemblyId) throw new Error('No assembly_id in result')
+      const assemblyUrl =
+        result.assembly_ssl_url ??
+        result.assembly_url ??
+        ('getLastUsedAssemblyUrl' in client && typeof client.getLastUsedAssemblyUrl === 'function'
+          ? client.getLastUsedAssemblyUrl()
+          : null)
+      const assemblyReference = formatAssemblyReference({ assemblyId, assemblyUrl })
 
-      const assembly = await client.awaitAssemblyCompletion(assemblyId, {
-        signal: abortController.signal,
-        onPoll: () => true,
-        onAssemblyProgress: (status) => {
-          outputctl.debug(`Assembly status: ${status.ok}`)
-        },
-      })
+      let assembly: Awaited<ReturnType<typeof client.awaitAssemblyCompletion>>
+      try {
+        assembly = await client.awaitAssemblyCompletion(assemblyId, {
+          signal: abortController.signal,
+          onPoll: () => true,
+          onAssemblyProgress: (status) => {
+            outputctl.debug(`Assembly status: ${status.ok}`)
+          },
+        })
+      } catch (err) {
+        const error = ensureError(err)
+        throw new Error(`${error.message} (${assemblyReference})`, { cause: error })
+      }
 
       if (assembly.error || (assembly.ok && assembly.ok !== 'ASSEMBLY_COMPLETED')) {
-        const msg = `Assembly failed: ${assembly.error || assembly.message} (Status: ${assembly.ok})`
-        outputctl.error(msg)
+        const msg = `Assembly failed: ${assembly.error || assembly.message} (Status: ${assembly.ok}, ${assemblyReference})`
         throw new Error(msg)
       }
 

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -792,7 +792,9 @@ describe('assemblies create', () => {
     await utimes(inputPath, secondChangeTime, secondChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await delay(20)
+    await vi.waitFor(() => {
+      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
+    })
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(
@@ -892,7 +894,9 @@ describe('assemblies create', () => {
     await utimes(inputPath, secondChangeTime, secondChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await delay(20)
+    await vi.waitFor(() => {
+      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
+    })
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(
@@ -998,7 +1002,9 @@ describe('assemblies create', () => {
     await utimes(inputPath, secondChangeTime, secondChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await delay(20)
+    await vi.waitFor(() => {
+      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
+    })
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -722,7 +722,7 @@ describe('assemblies create', () => {
     vi.doMock('node-watch', () => {
       return {
         default: vi.fn(() => {
-          resolveWatcherReady?.()
+          process.nextTick(() => resolveWatcherReady?.())
           return fakeWatcher
         }),
       }
@@ -739,20 +739,30 @@ describe('assemblies create', () => {
 
     const baseTime = new Date('2026-01-01T00:00:00.000Z')
     const outputTime = new Date('2026-01-01T00:00:10.000Z')
-    const firstChangeTime = new Date('2026-01-01T00:00:20.000Z')
-    const secondChangeTime = new Date('2026-01-01T00:00:30.000Z')
+    const updatedInputTime = new Date('2026-01-01T00:00:30.000Z')
 
     await utimes(inputPath, baseTime, baseTime)
     await utimes(outputPath, outputTime, outputTime)
 
+    let resolveWatchStarted: (() => void) | null = null
+    const watchStarted = new Promise<void>((resolve) => {
+      resolveWatchStarted = resolve
+    })
+    let createAssemblyCallCount = 0
     const output = new OutputCtl()
     const client = {
-      createAssembly: vi
-        .fn()
-        .mockResolvedValueOnce({ assembly_id: 'assembly-old' })
-        .mockResolvedValueOnce({ assembly_id: 'assembly-new' }),
+      createAssembly: vi.fn(() => {
+        createAssemblyCallCount += 1
+        if (createAssemblyCallCount === 1) {
+          return { assembly_id: 'assembly-old' }
+        }
+
+        resolveWatchStarted?.()
+        return { assembly_id: 'assembly-new' }
+      }),
       awaitAssemblyCompletion: vi.fn(async (assemblyId: string) => {
         if (assemblyId === 'assembly-old') {
+          await watchStarted
           await delay(80)
           return {
             ok: 'ASSEMBLY_COMPLETED',
@@ -791,17 +801,13 @@ describe('assemblies create', () => {
 
     await watcherReady
     await writeFile(inputPath, 'video-v2')
-    await utimes(inputPath, firstChangeTime, firstChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
-
-    await delay(5)
     await writeFile(inputPath, 'video-v3')
-    await utimes(inputPath, secondChangeTime, secondChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await vi.waitFor(() => {
-      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
-    })
+    await watchStarted
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(
@@ -831,7 +837,7 @@ describe('assemblies create', () => {
     vi.doMock('node-watch', () => {
       return {
         default: vi.fn(() => {
-          resolveWatcherReady?.()
+          process.nextTick(() => resolveWatcherReady?.())
           return fakeWatcher
         }),
       }
@@ -848,20 +854,30 @@ describe('assemblies create', () => {
 
     const baseTime = new Date('2026-01-01T00:00:00.000Z')
     const outputTime = new Date('2026-01-01T00:00:10.000Z')
-    const firstChangeTime = new Date('2026-01-01T00:00:20.000Z')
-    const secondChangeTime = new Date('2026-01-01T00:00:30.000Z')
+    const updatedInputTime = new Date('2026-01-01T00:00:30.000Z')
 
     await utimes(inputPath, baseTime, baseTime)
     await utimes(outputPath, outputTime, outputTime)
 
+    let resolveWatchStarted: (() => void) | null = null
+    const watchStarted = new Promise<void>((resolve) => {
+      resolveWatchStarted = resolve
+    })
+    let createAssemblyCallCount = 0
     const output = new OutputCtl()
     const client = {
-      createAssembly: vi
-        .fn()
-        .mockResolvedValueOnce({ assembly_id: 'assembly-old' })
-        .mockResolvedValueOnce({ assembly_id: 'assembly-new' }),
+      createAssembly: vi.fn(() => {
+        createAssemblyCallCount += 1
+        if (createAssemblyCallCount === 1) {
+          return { assembly_id: 'assembly-old' }
+        }
+
+        resolveWatchStarted?.()
+        return { assembly_id: 'assembly-new' }
+      }),
       awaitAssemblyCompletion: vi.fn(async (assemblyId: string) => {
         if (assemblyId === 'assembly-old') {
+          await watchStarted
           await delay(80)
           return {
             ok: 'ASSEMBLY_COMPLETED',
@@ -900,17 +916,13 @@ describe('assemblies create', () => {
 
     await watcherReady
     await writeFile(inputPath, 'video-v2')
-    await utimes(inputPath, firstChangeTime, firstChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
-
-    await delay(5)
     await writeFile(inputPath, 'video-v3')
-    await utimes(inputPath, secondChangeTime, secondChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await vi.waitFor(() => {
-      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
-    })
+    await watchStarted
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(
@@ -946,7 +958,7 @@ describe('assemblies create', () => {
     vi.doMock('node-watch', () => {
       return {
         default: vi.fn(() => {
-          resolveWatcherReady?.()
+          process.nextTick(() => resolveWatcherReady?.())
           return fakeWatcher
         }),
       }
@@ -963,20 +975,30 @@ describe('assemblies create', () => {
 
     const baseTime = new Date('2026-01-01T00:00:00.000Z')
     const outputTime = new Date('2026-01-01T00:00:10.000Z')
-    const firstChangeTime = new Date('2026-01-01T00:00:20.000Z')
-    const secondChangeTime = new Date('2026-01-01T00:00:30.000Z')
+    const updatedInputTime = new Date('2026-01-01T00:00:30.000Z')
 
     await utimes(inputPath, baseTime, baseTime)
     await utimes(outputPath, outputTime, outputTime)
 
+    let resolveWatchStarted: (() => void) | null = null
+    const watchStarted = new Promise<void>((resolve) => {
+      resolveWatchStarted = resolve
+    })
+    let createAssemblyCallCount = 0
     const output = new OutputCtl()
     const client = {
-      createAssembly: vi
-        .fn()
-        .mockResolvedValueOnce({ assembly_id: 'assembly-old-fast' })
-        .mockResolvedValueOnce({ assembly_id: 'assembly-new-slow' }),
+      createAssembly: vi.fn(() => {
+        createAssemblyCallCount += 1
+        if (createAssemblyCallCount === 1) {
+          return { assembly_id: 'assembly-old-fast' }
+        }
+
+        resolveWatchStarted?.()
+        return { assembly_id: 'assembly-new-slow' }
+      }),
       awaitAssemblyCompletion: vi.fn(async (assemblyId: string) => {
         if (assemblyId === 'assembly-old-fast') {
+          await watchStarted
           await delay(40)
           return {
             ok: 'ASSEMBLY_COMPLETED',
@@ -1015,17 +1037,13 @@ describe('assemblies create', () => {
 
     await watcherReady
     await writeFile(inputPath, 'video-v2')
-    await utimes(inputPath, firstChangeTime, firstChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
-
-    await delay(5)
     await writeFile(inputPath, 'video-v3')
-    await utimes(inputPath, secondChangeTime, secondChangeTime)
+    await utimes(inputPath, updatedInputTime, updatedInputTime)
     fakeWatcher.emit('change', 'update', inputPath)
 
-    await vi.waitFor(() => {
-      expect(client.awaitAssemblyCompletion).toHaveBeenCalledTimes(2)
-    })
+    await watchStarted
     fakeWatcher.close()
 
     await expect(createPromise).resolves.toEqual(

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -715,9 +715,16 @@ describe('assemblies create', () => {
     }
 
     const fakeWatcher = new FakeWatcher()
+    let resolveWatcherReady: (() => void) | null = null
+    const watcherReady = new Promise<void>((resolve) => {
+      resolveWatcherReady = resolve
+    })
     vi.doMock('node-watch', () => {
       return {
-        default: vi.fn(() => fakeWatcher),
+        default: vi.fn(() => {
+          resolveWatcherReady?.()
+          return fakeWatcher
+        }),
       }
     })
 
@@ -782,7 +789,7 @@ describe('assemblies create', () => {
       },
     })
 
-    await delay(20)
+    await watcherReady
     await writeFile(inputPath, 'video-v2')
     await utimes(inputPath, firstChangeTime, firstChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)
@@ -817,9 +824,16 @@ describe('assemblies create', () => {
     }
 
     const fakeWatcher = new FakeWatcher()
+    let resolveWatcherReady: (() => void) | null = null
+    const watcherReady = new Promise<void>((resolve) => {
+      resolveWatcherReady = resolve
+    })
     vi.doMock('node-watch', () => {
       return {
-        default: vi.fn(() => fakeWatcher),
+        default: vi.fn(() => {
+          resolveWatcherReady?.()
+          return fakeWatcher
+        }),
       }
     })
 
@@ -884,7 +898,7 @@ describe('assemblies create', () => {
       },
     })
 
-    await delay(20)
+    await watcherReady
     await writeFile(inputPath, 'video-v2')
     await utimes(inputPath, firstChangeTime, firstChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)
@@ -925,9 +939,16 @@ describe('assemblies create', () => {
     }
 
     const fakeWatcher = new FakeWatcher()
+    let resolveWatcherReady: (() => void) | null = null
+    const watcherReady = new Promise<void>((resolve) => {
+      resolveWatcherReady = resolve
+    })
     vi.doMock('node-watch', () => {
       return {
-        default: vi.fn(() => fakeWatcher),
+        default: vi.fn(() => {
+          resolveWatcherReady?.()
+          return fakeWatcher
+        }),
       }
     })
 
@@ -992,7 +1013,7 @@ describe('assemblies create', () => {
       },
     })
 
-    await delay(20)
+    await watcherReady
     await writeFile(inputPath, 'video-v2')
     await utimes(inputPath, firstChangeTime, firstChangeTime)
     fakeWatcher.emit('change', 'update', inputPath)

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -1413,4 +1413,72 @@ describe('assemblies create', () => {
     expect(loggedError).toBeInstanceOf(Error)
     expect((loggedError as Error).message).toContain('Polling timed out')
   })
+
+  it('does not report another assembly URL when concurrent polling times out', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const tempDir = await createTempDir('transloadit-timeout-concurrent-url-')
+    const inputA = path.join(tempDir, 'a.jpg')
+    const inputB = path.join(tempDir, 'b.jpg')
+
+    await writeFile(inputA, 'image-a')
+    await writeFile(inputB, 'image-b')
+
+    const output = new OutputCtl()
+    const client = {
+      createAssembly: vi
+        .fn()
+        .mockResolvedValueOnce({ assembly_id: 'assembly-one' })
+        .mockResolvedValueOnce({ assembly_id: 'assembly-two' }),
+      getLastUsedAssemblyUrl: vi
+        .fn()
+        .mockReturnValue('https://api2.transloadit.com/assemblies/assembly-two'),
+      awaitAssemblyCompletion: vi.fn(async (assemblyId: string) => {
+        if (assemblyId === 'assembly-one') {
+          await delay(30)
+          throw new PollingTimeoutError('Polling timed out')
+        }
+
+        await delay(5)
+        return {
+          ok: 'ASSEMBLY_COMPLETED',
+          results: {
+            resized: [{ url: 'http://downloads.test/result-two.jpg', name: 'result-two.jpg' }],
+          },
+        }
+      }),
+    }
+
+    await expect(
+      create(output, client as never, {
+        concurrency: 2,
+        inputs: [inputA, inputB],
+        output: null,
+        stepsData: {
+          resized: {
+            robot: '/image/resize',
+            result: true,
+            use: ':original',
+            width: 200,
+          },
+        },
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        hasFailures: true,
+      }),
+    )
+
+    const loggedError = consoleError.mock.calls.find(
+      ([prefix, value]) =>
+        prefix === 'err    ' &&
+        value instanceof Error &&
+        value.message.includes('Assembly ID: assembly-one'),
+    )?.[1]
+
+    expect(loggedError).toBeInstanceOf(Error)
+    expect((loggedError as Error).message).not.toContain(
+      'https://api2.transloadit.com/assemblies/assembly-two',
+    )
+  })
 })

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { create } from '../../../src/cli/commands/assemblies.ts'
 import OutputCtl from '../../../src/cli/OutputCtl.ts'
 import { parseStepsInputJson } from '../../../src/cli/stepsInput.ts'
+import PollingTimeoutError from '../../../src/PollingTimeoutError.ts'
 
 const tempDirs: string[] = []
 
@@ -1359,5 +1360,57 @@ describe('assemblies create', () => {
     await expect(stat(outputPath)).rejects.toMatchObject({
       code: 'ENOENT',
     })
+  })
+
+  it('includes the assembly URL when polling times out', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const tempDir = await createTempDir('transloadit-timeout-url-')
+    const inputPath = path.join(tempDir, 'image.jpg')
+    const outputPath = path.join(tempDir, 'resized.jpg')
+
+    await writeFile(inputPath, 'image-data')
+
+    const output = new OutputCtl()
+    const client = {
+      createAssembly: vi.fn().mockResolvedValue({
+        assembly_id: 'assembly-timeout',
+        assembly_ssl_url: 'https://api2.transloadit.com/assemblies/assembly-timeout',
+      }),
+      awaitAssemblyCompletion: vi
+        .fn()
+        .mockRejectedValue(new PollingTimeoutError('Polling timed out')),
+    }
+
+    await expect(
+      create(output, client as never, {
+        inputs: [inputPath],
+        output: outputPath,
+        stepsData: {
+          resized: {
+            robot: '/image/resize',
+            result: true,
+            use: ':original',
+            width: 200,
+          },
+        },
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        hasFailures: true,
+      }),
+    )
+
+    const loggedError = consoleError.mock.calls.find(
+      ([prefix, value]) =>
+        prefix === 'err    ' &&
+        value instanceof Error &&
+        value.message.includes(
+          'Assembly URL: https://api2.transloadit.com/assemblies/assembly-timeout',
+        ),
+    )?.[1]
+
+    expect(loggedError).toBeInstanceOf(Error)
+    expect((loggedError as Error).message).toContain('Polling timed out')
   })
 })


### PR DESCRIPTION
## Summary
- include the assembly URL in `assemblies create` timeout and terminal failure output when the create response provides that URL
- avoid falling back to shared client state for assembly URLs, which could report the wrong assembly under concurrent jobs
- add unit coverage for both the timeout message and the concurrent fallback race

## Root Cause
The initial CLI improvement reused `client.getLastUsedAssemblyUrl()` when `createAssembly()` returned only an `assembly_id`. That value is mutable per client instance, so concurrent jobs could attach a different assembly's URL to a timeout or failure.

## Validation
- `yarn check`
- `~/code/dotfiles/bin/council.ts review`
- `yarn check`
