### PR TITLE
Add gpt-image-2 image generate intent support

### DIFF
--- a/.changeset/cool-carpets-clap.md
+++ b/.changeset/cool-carpets-clap.md
@@ -1,0 +1,7 @@
+---
+'@transloadit/node': patch
+'@transloadit/mcp-server': patch
+'transloadit': patch
+---
+
+Document and test `gpt-image-2` support in the image generation intent flow.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -236,7 +236,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -250,6 +250,8 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 ```bash
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
+# Generate with OpenAI gpt-image-2
+transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images
@@ -1850,6 +1852,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 

--- a/packages/node/docs/intent-commands.md
+++ b/packages/node/docs/intent-commands.md
@@ -104,7 +104,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -118,6 +118,8 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 ```bash
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
+# Generate with OpenAI gpt-image-2
+transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images

--- a/packages/node/src/alphalib/types/robots/image-generate.ts
+++ b/packages/node/src/alphalib/types/robots/image-generate.ts
@@ -85,7 +85,7 @@ Best practice:
       .string()
       .optional()
       .describe(
-        'The AI model to use. Defaults to google/nano-banana. Supported models include flux-1.1-pro-ultra, flux-schnell, recraft-v3, google/nano-banana, google/nano-banana-2, google/nano-banana-pro, and stability-ai/stable-diffusion-inpainting.',
+        'The AI model to use. Defaults to google/nano-banana. Supported models include flux-1.1-pro-ultra, flux-schnell, recraft-v3, google/nano-banana, google/nano-banana-2, google/nano-banana-pro, gpt-image-2, and stability-ai/stable-diffusion-inpainting.',
       ),
     prompt: z
       .string()
@@ -96,7 +96,7 @@ Best practice:
       .enum(['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg'])
       .optional()
       .describe(
-        'Output format. Defaults depend on model: png for Google models, svg for recraft-v3, jpeg for others. Google models currently return PNG only.',
+        'Output format. Defaults depend on model: png for Google models and gpt-image-2, svg for recraft-v3, jpeg for others. Google models currently return PNG only.',
       ),
     seed: z.number().optional().describe('Seed for the random number generator.'),
     aspect_ratio: z
@@ -108,11 +108,11 @@ Best practice:
     height: z
       .number()
       .optional()
-      .describe('Requested output height in pixels (mainly used by Google image models).'),
+      .describe('Requested output height in pixels (mainly used by Google image models and gpt-image-2).'),
     width: z
       .number()
       .optional()
-      .describe('Requested output width in pixels (mainly used by Google image models).'),
+      .describe('Requested output width in pixels (mainly used by Google image models and gpt-image-2).'),
     style: z.string().optional().describe('Style of the generated image.'),
     num_outputs: z
       .number()

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -21,7 +21,7 @@ const imageGenerateOptionDefinitions = [
     kind: 'string',
     propertyName: 'model',
     optionFlags: '--model',
-    description: `The AI model to use for image generation. Defaults to ${defaultImageGenerateModel}.`,
+    description: `The AI model to use for image generation. Defaults to ${defaultImageGenerateModel}. Backend-supported models include gpt-image-2 and Google Nano Banana variants.`,
     required: false,
     exampleValue: defaultImageGenerateModel,
   },
@@ -92,6 +92,10 @@ const imageGenerateCommandPresentation = {
     [
       'Generate an image from text',
       'transloadit image generate --prompt "A red bicycle in a studio" --output output.png',
+    ],
+    [
+      'Generate with OpenAI gpt-image-2',
+      'transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png',
     ],
     [
       'Guide generation with one input image',

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -524,6 +524,44 @@ describe('intent commands', () => {
     )
   })
 
+  it('passes through gpt-image-2 and explicit dimensions for image generate', async () => {
+    const { createSpy } = await runIntentCommand([
+      'image',
+      'generate',
+      '--prompt',
+      'A ceramic coffee mug on a white sweep',
+      '--model',
+      'gpt-image-2',
+      '--width',
+      '1024',
+      '--height',
+      '1024',
+      '--format',
+      'png',
+      '--output',
+      'generated.png',
+    ])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.any(OutputCtl),
+      expect.anything(),
+      expect.objectContaining({
+        stepsData: {
+          generate: expect.objectContaining({
+            robot: '/image/generate',
+            model: 'gpt-image-2',
+            prompt: 'A ceramic coffee mug on a white sweep',
+            width: 1024,
+            height: 1024,
+            format: 'png',
+            result: true,
+          }),
+        },
+      }),
+    )
+  })
+
   it('bundles image generate inputs into a single /image/generate step', async () => {
     const { createSpy } = await runIntentCommand([
       'image',

--- a/packages/node/test/unit/robots.test.ts
+++ b/packages/node/test/unit/robots.test.ts
@@ -34,4 +34,11 @@ describe('robot catalog helpers', () => {
     expect(Array.isArray(help.examples)).toBe(true)
     expect(help.examples?.length).toBeGreaterThan(0)
   })
+
+  it('includes gpt-image-2 in /image/generate model help text', () => {
+    const help = getRobotHelp({ robotName: '/image/generate', detailLevel: 'full' })
+    const modelParam = help.optionalParams.find((param) => param.name === 'model')
+
+    expect(modelParam?.description).toContain('gpt-image-2')
+  })
 })

--- a/packages/transloadit/README.md
+++ b/packages/transloadit/README.md
@@ -236,7 +236,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -250,6 +250,8 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 ```bash
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
+# Generate with OpenAI gpt-image-2
+transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images
@@ -1850,6 +1852,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 


### PR DESCRIPTION
## Summary
- document `gpt-image-2` support in the `image generate` intent flow
- add an explicit `gpt-image-2` example to the CLI docs
- cover the intent mapping and robot help text with unit tests

## Verification
- yarn workspace @transloadit/node test:unit --run packages/node/test/unit/cli/intents.test.ts packages/node/test/unit/robots.test.ts
- yarn check
- real CLI run via `node packages/node/src/cli.ts image generate --model gpt-image-2 ...`
