### PR TITLE
Use canonical OpenAI image model spelling

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -236,7 +236,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include openai/gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -251,7 +251,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
 # Generate with OpenAI gpt-image-2
-transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
+transloadit image generate --model openai/gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images
@@ -1852,6 +1852,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 

--- a/packages/node/docs/intent-commands.md
+++ b/packages/node/docs/intent-commands.md
@@ -104,7 +104,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include openai/gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -119,7 +119,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
 # Generate with OpenAI gpt-image-2
-transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
+transloadit image generate --model openai/gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images

--- a/packages/node/src/alphalib/types/robots/image-generate.ts
+++ b/packages/node/src/alphalib/types/robots/image-generate.ts
@@ -85,7 +85,7 @@ Best practice:
       .string()
       .optional()
       .describe(
-        'The AI model to use. Defaults to google/nano-banana. Supported models include flux-1.1-pro-ultra, flux-schnell, recraft-v3, google/nano-banana, google/nano-banana-2, google/nano-banana-pro, gpt-image-2, and stability-ai/stable-diffusion-inpainting.',
+        'The AI model to use. Defaults to google/nano-banana. Supported models include flux-1.1-pro-ultra, flux-schnell, recraft-v3, google/nano-banana, google/nano-banana-2, google/nano-banana-pro, openai/gpt-image-2, and stability-ai/stable-diffusion-inpainting. The legacy alias gpt-image-2 is also accepted for backwards compatibility.',
       ),
     prompt: z
       .string()
@@ -96,7 +96,7 @@ Best practice:
       .enum(['jpeg', 'jpg', 'png', 'gif', 'webp', 'svg'])
       .optional()
       .describe(
-        'Output format. Defaults depend on model: png for Google models and gpt-image-2, svg for recraft-v3, jpeg for others. Google models currently return PNG only.',
+        'Output format. Defaults depend on model: png for Google models and openai/gpt-image-2, svg for recraft-v3, jpeg for others. Google models currently return PNG only.',
       ),
     seed: z.number().optional().describe('Seed for the random number generator.'),
     aspect_ratio: z
@@ -108,11 +108,15 @@ Best practice:
     height: z
       .number()
       .optional()
-      .describe('Requested output height in pixels (mainly used by Google image models and gpt-image-2).'),
+      .describe(
+        'Requested output height in pixels (mainly used by Google image models and openai/gpt-image-2).',
+      ),
     width: z
       .number()
       .optional()
-      .describe('Requested output width in pixels (mainly used by Google image models and gpt-image-2).'),
+      .describe(
+        'Requested output width in pixels (mainly used by Google image models and openai/gpt-image-2).',
+      ),
     style: z.string().optional().describe('Style of the generated image.'),
     num_outputs: z
       .number()

--- a/packages/node/src/cli/semanticIntents/imageGenerate.ts
+++ b/packages/node/src/cli/semanticIntents/imageGenerate.ts
@@ -21,7 +21,7 @@ const imageGenerateOptionDefinitions = [
     kind: 'string',
     propertyName: 'model',
     optionFlags: '--model',
-    description: `The AI model to use for image generation. Defaults to ${defaultImageGenerateModel}. Backend-supported models include gpt-image-2 and Google Nano Banana variants.`,
+    description: `The AI model to use for image generation. Defaults to ${defaultImageGenerateModel}. Backend-supported models include openai/gpt-image-2 and Google Nano Banana variants.`,
     required: false,
     exampleValue: defaultImageGenerateModel,
   },
@@ -95,7 +95,7 @@ const imageGenerateCommandPresentation = {
     ],
     [
       'Generate with OpenAI gpt-image-2',
-      'transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png',
+      'transloadit image generate --model openai/gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png',
     ],
     [
       'Guide generation with one input image',

--- a/packages/node/test/unit/cli/intents.test.ts
+++ b/packages/node/test/unit/cli/intents.test.ts
@@ -524,14 +524,14 @@ describe('intent commands', () => {
     )
   })
 
-  it('passes through gpt-image-2 and explicit dimensions for image generate', async () => {
+  it('passes through openai/gpt-image-2 and explicit dimensions for image generate', async () => {
     const { createSpy } = await runIntentCommand([
       'image',
       'generate',
       '--prompt',
       'A ceramic coffee mug on a white sweep',
       '--model',
-      'gpt-image-2',
+      'openai/gpt-image-2',
       '--width',
       '1024',
       '--height',
@@ -550,7 +550,7 @@ describe('intent commands', () => {
         stepsData: {
           generate: expect.objectContaining({
             robot: '/image/generate',
-            model: 'gpt-image-2',
+            model: 'openai/gpt-image-2',
             prompt: 'A ceramic coffee mug on a white sweep',
             width: 1024,
             height: 1024,

--- a/packages/transloadit/README.md
+++ b/packages/transloadit/README.md
@@ -236,7 +236,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 | Flag | Type | Required | Example | Description |
 | --- | --- | --- | --- | --- |
 | `--prompt` | `string` | yes | `"A red bicycle in a studio"` | The prompt describing the desired image content. |
-| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include gpt-image-2 and Google Nano Banana variants. |
+| `--model` | `string` | no | `google/nano-banana-2` | The AI model to use for image generation. Defaults to google/nano-banana-2. Backend-supported models include openai/gpt-image-2 and Google Nano Banana variants. |
 | `--format` | `string` | no | `jpg` | Format of the generated image. |
 | `--seed` | `number` | no | — | Seed for the random number generator. |
 | `--aspect-ratio` | `string` | no | — | Aspect ratio of the generated image. |
@@ -251,7 +251,7 @@ npx transloadit image generate [--input <path|dir|url|->] [options]
 # Generate an image from text
 transloadit image generate --prompt "A red bicycle in a studio" --output output.png
 # Generate with OpenAI gpt-image-2
-transloadit image generate --model gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
+transloadit image generate --model openai/gpt-image-2 --width 1024 --height 1024 --prompt "A ceramic coffee mug on a white sweep" --output output.png
 # Guide generation with one input image
 transloadit image generate --input subject.jpg --prompt "Place subject.jpg on a magazine cover" --output output.png
 # Guide generation with multiple input images
@@ -1852,6 +1852,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 


### PR DESCRIPTION
## Summary
- switch node-sdk image-generate docs and examples to `openai/gpt-image-2`
- keep the compatibility note in the robot docs for the legacy `gpt-image-2` alias
- regenerate intent docs and package READMEs

## Testing
- yarn check
