### PR TITLE
Add image upscale intent wrapping /image/upscale

### DIFF
--- a/.changeset/image-upscale-intent.md
+++ b/.changeset/image-upscale-intent.md
@@ -1,0 +1,9 @@
+---
+'@transloadit/node': minor
+'@transloadit/mcp-server': patch
+'transloadit': minor
+---
+
+Add an `image upscale` intent command that wires up the `/image/upscale` Robot for AI image
+upscaling. Flags `--model` (`nightmareai/real-esrgan` by default, plus `tencentarc/gfpgan` and
+`sczhou/codeformer`), `--scale` (2 or 4), and `--face-enhance` are derived from the robot schema.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -150,6 +150,7 @@ All intent commands also support the global CLI flags `--json`, `--log-level`, `
 | `image merge` | Merge several images into a single image | file, dir, URL, base64 | file |
 | `image optimize` | Optimize images without quality loss | file, dir, URL, base64 | file |
 | `image resize` | Convert, resize, or watermark images | file, dir, URL, base64 | file |
+| `image upscale` | Upscale images | file, dir, URL, base64 | file |
 | `document convert` | Convert documents into different formats | file, dir, URL, base64 | file |
 | `document optimize` | Reduce PDF file size | file, dir, URL, base64 | file |
 | `document auto-rotate` | Auto-rotate documents to the correct orientation | file, dir, URL, base64 | file |
@@ -523,6 +524,44 @@ npx transloadit image resize --input <path|dir|url|-> [options]
 
 ```bash
 transloadit image resize --input input.png --output output.png
+```
+
+#### `image upscale`
+
+Upscale images
+
+Runs `/image/upscale` on each input file and writes the result to `--output`.
+
+**Usage**
+
+```bash
+npx transloadit image upscale --input <path|dir|url|-> [options]
+```
+
+**Quick facts**
+
+- Input: file, dir, URL, base64
+- Output: file
+- Execution: per-file; supports `--single-assembly` and `--watch`
+- Backend: `/image/upscale`
+
+**Shared flags**
+
+- Uses the shared file input and output flags listed above.
+- Also supports the shared base processing flags, watch flags, bundling flags listed above.
+
+**Command options**
+
+| Flag | Type | Required | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--model` | `string` | no | `nightmareai/real-esrgan` | The AI model to use for image upscaling. Defaults to nightmareai/real-esrgan. |
+| `--scale` | `number` | no | `2` | Upscale factor. Defaults to 2. |
+| `--face-enhance` | `boolean` | no | `true` | Enable face enhancement for better face restoration. Defaults to false. |
+
+**Examples**
+
+```bash
+transloadit image upscale --input input.png --output output.png
 ```
 
 #### `document convert`
@@ -1852,6 +1891,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 

--- a/packages/node/docs/intent-commands.md
+++ b/packages/node/docs/intent-commands.md
@@ -18,6 +18,7 @@ All intent commands also support the global CLI flags `--json`, `--log-level`, `
 | `image merge` | Merge several images into a single image | file, dir, URL, base64 | file |
 | `image optimize` | Optimize images without quality loss | file, dir, URL, base64 | file |
 | `image resize` | Convert, resize, or watermark images | file, dir, URL, base64 | file |
+| `image upscale` | Upscale images | file, dir, URL, base64 | file |
 | `document convert` | Convert documents into different formats | file, dir, URL, base64 | file |
 | `document optimize` | Reduce PDF file size | file, dir, URL, base64 | file |
 | `document auto-rotate` | Auto-rotate documents to the correct orientation | file, dir, URL, base64 | file |
@@ -391,6 +392,44 @@ npx transloadit image resize --input <path|dir|url|-> [options]
 
 ```bash
 transloadit image resize --input input.png --output output.png
+```
+
+## `image upscale`
+
+Upscale images
+
+Runs `/image/upscale` on each input file and writes the result to `--output`.
+
+**Usage**
+
+```bash
+npx transloadit image upscale --input <path|dir|url|-> [options]
+```
+
+**Quick facts**
+
+- Input: file, dir, URL, base64
+- Output: file
+- Execution: per-file; supports `--single-assembly` and `--watch`
+- Backend: `/image/upscale`
+
+**Shared flags**
+
+- Uses the shared file input and output flags listed above.
+- Also supports the shared base processing flags, watch flags, bundling flags listed above.
+
+**Command options**
+
+| Flag | Type | Required | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--model` | `string` | no | `nightmareai/real-esrgan` | The AI model to use for image upscaling. Defaults to nightmareai/real-esrgan. |
+| `--scale` | `number` | no | `2` | Upscale factor. Defaults to 2. |
+| `--face-enhance` | `boolean` | no | `true` | Enable face enhancement for better face restoration. Defaults to false. |
+
+**Examples**
+
+```bash
+transloadit image upscale --input input.png --output output.png
 ```
 
 ## `document convert`

--- a/packages/node/src/cli/intentCommandSpecs.ts
+++ b/packages/node/src/cli/intentCommandSpecs.ts
@@ -50,6 +50,10 @@ import {
   meta as robotImageResizeMeta,
 } from '../alphalib/types/robots/image-resize.ts'
 import {
+  robotImageUpscaleInstructionsSchema,
+  meta as robotImageUpscaleMeta,
+} from '../alphalib/types/robots/image-upscale.ts'
+import {
   robotTextSpeakInstructionsSchema,
   meta as robotTextSpeakMeta,
 } from '../alphalib/types/robots/text-speak.ts'
@@ -205,6 +209,12 @@ export const intentCatalog = [
     robot: '/image/resize',
     meta: robotImageResizeMeta,
     schema: robotImageResizeInstructionsSchema,
+  }),
+  defineRobotIntent({
+    kind: 'robot',
+    robot: '/image/upscale',
+    meta: robotImageUpscaleMeta,
+    schema: robotImageUpscaleInstructionsSchema,
   }),
   defineRobotIntent({
     kind: 'robot',

--- a/packages/node/test/support/intentSmokeCases.ts
+++ b/packages/node/test/support/intentSmokeCases.ts
@@ -100,6 +100,11 @@ const intentSmokeOverrides: Record<string, Omit<IntentSmokeCase, 'key' | 'paths'
     outputPath: 'image-resize.jpg',
     verifier: 'jpeg',
   },
+  '/image/upscale': {
+    args: ['--input', '@fixture/input.jpg'],
+    outputPath: 'image-upscale.png',
+    verifier: 'png',
+  },
   '/text/speak': {
     args: ['--prompt', 'Hello from the Transloadit Node CLI intents test.', '--provider', 'aws'],
     outputPath: 'text-speak.mp3',

--- a/packages/transloadit/README.md
+++ b/packages/transloadit/README.md
@@ -150,6 +150,7 @@ All intent commands also support the global CLI flags `--json`, `--log-level`, `
 | `image merge` | Merge several images into a single image | file, dir, URL, base64 | file |
 | `image optimize` | Optimize images without quality loss | file, dir, URL, base64 | file |
 | `image resize` | Convert, resize, or watermark images | file, dir, URL, base64 | file |
+| `image upscale` | Upscale images | file, dir, URL, base64 | file |
 | `document convert` | Convert documents into different formats | file, dir, URL, base64 | file |
 | `document optimize` | Reduce PDF file size | file, dir, URL, base64 | file |
 | `document auto-rotate` | Auto-rotate documents to the correct orientation | file, dir, URL, base64 | file |
@@ -523,6 +524,44 @@ npx transloadit image resize --input <path|dir|url|-> [options]
 
 ```bash
 transloadit image resize --input input.png --output output.png
+```
+
+#### `image upscale`
+
+Upscale images
+
+Runs `/image/upscale` on each input file and writes the result to `--output`.
+
+**Usage**
+
+```bash
+npx transloadit image upscale --input <path|dir|url|-> [options]
+```
+
+**Quick facts**
+
+- Input: file, dir, URL, base64
+- Output: file
+- Execution: per-file; supports `--single-assembly` and `--watch`
+- Backend: `/image/upscale`
+
+**Shared flags**
+
+- Uses the shared file input and output flags listed above.
+- Also supports the shared base processing flags, watch flags, bundling flags listed above.
+
+**Command options**
+
+| Flag | Type | Required | Example | Description |
+| --- | --- | --- | --- | --- |
+| `--model` | `string` | no | `nightmareai/real-esrgan` | The AI model to use for image upscaling. Defaults to nightmareai/real-esrgan. |
+| `--scale` | `number` | no | `2` | Upscale factor. Defaults to 2. |
+| `--face-enhance` | `boolean` | no | `true` | Enable face enhancement for better face restoration. Defaults to false. |
+
+**Examples**
+
+```bash
+transloadit image upscale --input input.png --output output.png
 ```
 
 #### `document convert`
@@ -1852,6 +1891,7 @@ Thanks to [Ian Hansen](https://github.com/supershabam) for donating the `translo
 ## Development
 
 See [CONTRIBUTING](./CONTRIBUTING.md).
+
 
 
 


### PR DESCRIPTION
## Summary

- Register `/image/upscale` in the intent catalog so the CLI exposes `transloadit image upscale`
- Flags (`--model`, `--scale`, `--face-enhance`) are auto-derived from the existing zod schema; `--model` defaults to `nightmareai/real-esrgan` (the Robot's server-side SOTA default), with `tencentarc/gfpgan` and `sczhou/codeformer` also selectable
- Regenerated `packages/node/docs/intent-commands.md`, `packages/node/README.md`, and the linked `packages/transloadit/README.md`; added a smoke case so the catalog/commands/smoke sync test stays green
- Ships with a changeset (`minor` for `@transloadit/node` and `transloadit`, `patch` for `@transloadit/mcp-server`) so Changesets will open a Version Packages PR on merge

## Test plan

- [x] `yarn lint:changesets`
- [x] `yarn lint:ts` (packages/node)
- [x] `yarn lint:js` (packages/node)
- [x] `yarn test:unit` (packages/node) — 229 passed
- [x] `yarn lint:transloadit-sync` (clean tree post-commit)
- [x] `node scripts/prepare-transloadit.ts` regenerated the legacy wrapper in-tree
- [ ] CI runs verify across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)