### PR TITLE
Enforce SHA-384 signature generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Retrieves the billing data for a given `date` string with format `YYYY-MM`. See 
 #### calcSignature(params)
 
 Calculates a signature for the given `params` JSON object. If the `params` object does not include an `authKey` or `expires` keys (and their values) in the `auth` sub-key, then they are set automatically.
+Signatures are generated using `sha384`.
 
 This function returns an object with the key `signature` (containing the calculated signature string) and a key `params`, which contains the stringified version of the passed `params` object (including the set expires and authKey keys).
 

--- a/src/Transloadit.js
+++ b/src/Transloadit.js
@@ -569,7 +569,8 @@ class TransloaditClient {
     return { signature, params: jsonParams }
   }
 
-  _calcSignature(toSign, algorithm = 'sha384') {
+  _calcSignature(toSign) {
+    const algorithm = 'sha384'
     return `${algorithm}:${crypto
       .createHmac(algorithm, this._authSecret)
       .update(Buffer.from(toSign, 'utf-8'))

--- a/test/unit/__tests__/test-transloadit-client.js
+++ b/test/unit/__tests__/test-transloadit-client.js
@@ -272,6 +272,16 @@ describe('Transloadit', () => {
         'sha384:fc75f6a4bbb06340653c0f7efff013e94eb8e402e0e45cf40ad4bc95f45a3ae3263032000727359c595a433364a84f96'
       return expect(client._calcSignature('akjdkadskjads')).toBe(expected)
     })
+
+    it('should always generate sha384 signatures', () => {
+      const client = new Transloadit({ authKey: 'foo_key', authSecret: 'foo_secret' })
+      client._authSecret = '13123123123'
+
+      const expected =
+        'sha384:8b90663d4b7d14ac7d647c74cb53c529198dee4689d0f8faae44f0df1c2a157acce5cb8c55a375218bc331897cf92e9d'
+
+      expect(client._calcSignature('foo', 'sha1')).toBe(expected)
+    })
   })
 
   describe('_remoteJson', () => {


### PR DESCRIPTION
## Summary
- enforce SHA-384 as the only signature algorithm in `_calcSignature()`
- add a regression test to guarantee SHA-384 output even if extra args are passed
- document in README that `calcSignature()` returns SHA-384 signatures

## Why
API keys default to SHA-384, so allowing algorithm drift from SDK internals can cause avoidable auth failures in downstream integrations.

Fixes #400
