### PR TITLE
Add OpenAI GPT-5.5 defaults

### DIFF
--- a/packages/node/src/alphalib/types/robots/ai-chat.ts
+++ b/packages/node/src/alphalib/types/robots/ai-chat.ts
@@ -170,6 +170,7 @@ export const MODEL_CAPABILITIES: Record<string, { pdf: boolean; image: boolean }
   'openai/gpt-5.2-2025-12-11': { pdf: false, image: true },
   'openai/gpt-5.2-chat-latest': { pdf: false, image: true },
   'openai/gpt-5.2-pro': { pdf: false, image: true },
+  'openai/gpt-5.5': { pdf: false, image: true },
   'openai/gpt-5.4': { pdf: false, image: true },
   'openai/gpt-5.4-mini': { pdf: false, image: true },
   'openai/gpt-5.4-nano': { pdf: false, image: true },
@@ -178,10 +179,9 @@ export const MODEL_CAPABILITIES: Record<string, { pdf: boolean; image: boolean }
 }
 
 // Default model for /ai/chat when `model: "auto"` (or unset).
-// 2026-04-16: default is Opus 4.7 (intentional; aligns with our current recommended Anthropic
-// flagship model and the system tests in this repo). Keep this aligned with MODEL_CAPABILITIES.
-export const AI_CHAT_DEFAULT_MODEL =
-  'anthropic/claude-opus-4-7' satisfies keyof typeof MODEL_CAPABILITIES
+// 2026-04-29: default is GPT-5.5 (intentional; aligns with our current recommended OpenAI
+// flagship model). Keep this aligned with MODEL_CAPABILITIES.
+export const AI_CHAT_DEFAULT_MODEL = 'openai/gpt-5.5' satisfies keyof typeof MODEL_CAPABILITIES
 
 const supportedModelsList = Object.keys(MODEL_CAPABILITIES)
 
@@ -216,7 +216,7 @@ export const robotAiChatInstructionsSchema = robotBase
       .optional()
       .describe('Set the system/developer prompt, if the model allows it'),
     reasoning_effort: z
-      .enum(['high', 'medium', 'low'])
+      .enum(['xhigh', 'high', 'medium', 'low'])
       .optional()
       .describe(
         'Controls how much effort the model spends on reasoning. Higher values produce more thorough responses but cost more tokens. Applies to models that support extended thinking (OpenAI o-series, GPT-5.x, Anthropic Claude with thinking). If omitted, the model default is used.',


### PR DESCRIPTION
## Summary
- Update the synced `/ai/chat` robot type default to `openai/gpt-5.5`.
- Add the `gpt-5.5` capability entry and expose `xhigh` reasoning effort.

## Test plan
- [x] `corepack yarn check`
- [x] `git diff --check`

## Sister PRs
- transloadit/content#4980: https://github.com/transloadit/content/pull/4980
- transloadit/api2#7721: https://github.com/transloadit/api2/pull/7721
- transloadit/accounting#261: https://github.com/transloadit/accounting/pull/261
- transloadit/botty#172: https://github.com/transloadit/botty/pull/172
- transloadit/team-internals#523: https://github.com/transloadit/team-internals/pull/523
- kvz/arkivz#123: https://github.com/kvz/arkivz/pull/123
- kvz/dotfiles#12: https://github.com/kvz/dotfiles/pull/12
