### PR TITLE
Harden dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       - run: corepack yarn run pack
       - uses: actions/upload-artifact@v7
         with:
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       - run: corepack yarn verify
 
   verify-full:
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       - run: corepack yarn verify:full
 
   release-dry-run:
@@ -141,7 +141,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@11.5.1
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       - run: corepack yarn tsc:utils
       - run: corepack yarn tsc:zod
       - run: corepack yarn tsc:node
@@ -162,7 +162,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       # Root unit tests execute TypeScript scripts via Node's strip-types support.
       # Keep those on Node 24+; Node 20/22 only run @transloadit/node unit tests.
       - run: corepack yarn test:unit
@@ -191,7 +191,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
       - name: Download cloudflared
         run: |
           curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 -o cloudflared-linux-amd64 https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@11.5.1
-      - run: corepack yarn
-      - run: corepack yarn
+      - run: corepack yarn install --immutable
+      - run: corepack yarn install --immutable
       - run: corepack yarn tsc:utils
       - run: corepack yarn tsc:zod
       - run: corepack yarn tsc:node

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ packageExtensions:
     dependencies:
       "@emnapi/core": "1.10.0"
       "@emnapi/runtime": "1.10.0"
+
+npmMinimalAgeGate: 2880


### PR DESCRIPTION
## Why
Recent npm supply-chain compromises showed that dependency installs and shared CI caches can execute or preserve newly published malicious packages before advisories catch up. This PR reduces that exposure for this repo.

## What changed
- Added Yarn minimal age gate and made eligible Yarn installs immutable.

## Validation
- Ran `git diff --check` across the prepared worktree.
- Audited this PR set for `pull_request_target` and release/deploy/CDN cache reuse; patched actionable hits.
- Did not run the full test suite; this is a workflow/config-only change.