### PR TITLE
Add Claude Opus 4.8 support

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-opus-4-8

--- a/packages/node/src/alphalib/types/robots/ai-chat.ts
+++ b/packages/node/src/alphalib/types/robots/ai-chat.ts
@@ -1,5 +1,7 @@
-import { z } from 'zod'
 import type { RobotMetaInput } from './_instructions-primitives.ts'
+
+import { z } from 'zod'
+
 import { interpolateRobot, robotBase, robotUse } from './_instructions-primitives.ts'
 
 // We duplicate coreMessageSchema (and its related types) from structuredAiVercel.ts here
@@ -162,6 +164,7 @@ export const MODEL_CAPABILITIES: Record<string, { pdf: boolean; image: boolean }
   'anthropic/claude-opus-4-5': { pdf: true, image: true },
   'anthropic/claude-opus-4-6': { pdf: true, image: true },
   'anthropic/claude-opus-4-7': { pdf: true, image: true },
+  'anthropic/claude-opus-4-8': { pdf: true, image: true },
   'openai/gpt-4.1-2025-04-14': { pdf: false, image: true },
   'openai/chatgpt-4o-latest': { pdf: false, image: true },
   'openai/o3-2025-04-16': { pdf: false, image: true },


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-opus-4-8` to the node-sdk ai-chat capability map while keeping 4.7 supported.
- Move the Claude Code workflow model from Claude Opus 4.7 to Claude Opus 4.8.

## Test plan
- [x] `corepack yarn check`



## Sister PRs

- transloadit/content#5115
- transloadit/api2#8061
- transloadit/accounting#264
- transloadit/botty#187
- transloadit/team-internals#550
- kvz/clawfleet#8
- kvz/arkivz#129
- kvz/dotfiles#13
