### PR TITLE
Sign coverage publish commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,12 +228,20 @@ jobs:
         id: coverage-publish
         env:
           COVERAGE_REPO_SSH_PRIVATE_KEY: ${{ secrets.COVERAGE_REPO_SSH_PRIVATE_KEY }}
+          COVERAGE_REPO_SIGNING_SSH_KEY: ${{ secrets.COVERAGE_REPO_SIGNING_SSH_KEY }}
         run: |
-          if [ -n "$COVERAGE_REPO_SSH_PRIVATE_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Coverage publish skipped for pull request runs."
+          elif [ -z "$COVERAGE_REPO_SSH_PRIVATE_KEY" ]; then
             echo "enabled=false" >> "$GITHUB_OUTPUT"
             echo "Coverage publish skipped because COVERAGE_REPO_SSH_PRIVATE_KEY is unavailable."
+          elif [ -z "$COVERAGE_REPO_SIGNING_SSH_KEY" ]; then
+            echo "COVERAGE_REPO_SIGNING_SSH_KEY is required so generated coverage commits pass the verified-signature ruleset." >&2
+            echo "Add the public half of that key to the GitHub account used below as an SSH signing key." >&2
+            exit 1
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
       # *** BEGIN PUBLISH STATIC SITE STEPS ***
       # Use the standard checkout action to check out the destination repo to a separate directory
@@ -247,9 +255,18 @@ jobs:
 
       # Push coverage data
       - if: steps.coverage-publish.outputs.enabled == 'true'
+        env:
+          COVERAGE_REPO_SIGNING_SSH_KEY: ${{ secrets.COVERAGE_REPO_SIGNING_SSH_KEY }}
         run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
+          mkdir -p ~/.ssh
+          printf '%s\n' "$COVERAGE_REPO_SIGNING_SSH_KEY" > ~/.ssh/id_coverage_signing
+          chmod 600 ~/.ssh/id_coverage_signing
+          ssh-keygen -y -f ~/.ssh/id_coverage_signing > ~/.ssh/id_coverage_signing.pub
+          git config --global user.name "Transloadit Bot"
+          git config --global user.email "24697610+transloadit-bot@users.noreply.github.com"
+          git config --global gpg.format ssh
+          git config --global user.signingkey "$HOME/.ssh/id_coverage_signing.pub"
+          git config --global commit.gpgsign true
           # Remove existing files:
           rm -rf static-files-destination/*
           # Replace with new files:


### PR DESCRIPTION
Why

The Transloadit verified-commit ruleset now rejects unsigned generated commits. The scheduled CI run on `main` passed the E2E work, then failed while pushing `Static file updates` to `transloadit/node-sdk-coverage` because the generated commit was unsigned.

What changed

- Adds a required `COVERAGE_REPO_SIGNING_SSH_KEY` secret for coverage publishing.
- Signs generated coverage commits with SSH commit signing.
- Commits as `Transloadit Bot <24697610+transloadit-bot@users.noreply.github.com>`.
- Skips coverage publishing on pull request runs.

Signing key status

The private half has been stored as the `COVERAGE_REPO_SIGNING_SSH_KEY` secret on `transloadit/node-sdk`. The public half has been added to `transloadit-bot` as SSH signing key ID `985158`.

Validation

- `git diff --check`
- `yarn lint:changesets`
- `yarn lint:publish`
- PR CI: https://github.com/transloadit/node-sdk/actions/runs/27058839321
- Manual `workflow_dispatch` on `sign-coverage`: https://github.com/transloadit/node-sdk/actions/runs/27059000861

The manual run pushed a verified coverage commit to `transloadit/node-sdk-coverage:main`: https://github.com/transloadit/node-sdk-coverage/commit/b104331d2f5fefe7e78700dcdc910b04903e6d6e

`actionlint` is not installed locally. Biome intentionally ignores `.github/workflows/ci.yml` in this repo.