### PR TITLE
Replace Slack notification action and harden action refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,12 @@ jobs:
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: failure
+      - name: Send Slack notification
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_TEXT: >-
+            ${{ github.workflow }} failed for ${{ github.repository }} on ${{ github.ref_name }}:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          node -e "process.stdout.write(JSON.stringify({ text: process.env.SLACK_TEXT }))" |
+            curl --fail-with-body -X POST -H 'Content-type: application/json' --data-binary @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
           path: static-build
       - name: Deploy coverage to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   coverage:
     name: Upload coverage
@@ -267,7 +267,7 @@ jobs:
           name: coverage-reports
           path: coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by removing the third-party Slack notification action from the CI failure path.

What changed

- Replaces `8398a7/action-slack` with a direct incoming-webhook `curl` step.
- Keeps notifications scoped to main-branch E2E failures.

Validation

- Ruby YAML parse for `.github/workflows/ci.yml`
- `git diff --check`

Additional action reference hardening included here:

- Updates GitHub-owned actions in touched workflows to current major tags.
- Pins retained third-party actions in touched workflows to reviewed commit SHAs, keeping version comments beside each SHA.
