### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
 
       # can be used for debugging:
       #      - name: Setup tmate session
-      #        uses: mxschmitt/action-tmate@v3
+      #        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113
 
       - run: corepack yarn test
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/docker-mcp.yml
+++ b/.github/workflows/docker-mcp.yml
@@ -33,15 +33,15 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           context: packages/mcp-server
           file: packages/mcp-server/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: corepack yarn tsc:utils
       - run: corepack yarn tsc:zod
       - run: corepack yarn tsc:node
-      - uses: changesets/action@v1
+      - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           version: corepack yarn changeset:version:release
           publish: corepack yarn changeset publish


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/ci.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/docker-mcp.yml`
- `.github/workflows/release.yml`

Resolved refs:

- `mxschmitt/action-tmate@v3` -> `mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113`
- `anthropics/claude-code-action@beta` -> `anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f`
- `docker/build-push-action@v7` -> `docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf`
- `docker/login-action@v4` -> `docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee`
- `docker/setup-buildx-action@v4` -> `docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5`
- `changesets/action@v1` -> `changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
