### PR TITLE
Use signed Changesets release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: corepack yarn changeset:version:release
           publish: corepack yarn changeset publish
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Why

The post-merge release workflow failed when changesets/action tried to push changeset-release/main with an unsigned git-cli commit. Repository rules now require verified signatures, so the version PR branch was rejected before it could be opened.

What

- Switch changesets/action to commitMode: github-api so version commits and tags are GPG-signed by GitHub.

Validation

- corepack yarn check