### PR TITLE
Fix tus upload rejection handling

### DIFF
--- a/.changeset/smooth-tus-rejections.md
+++ b/.changeset/smooth-tus-rejections.md
@@ -1,0 +1,7 @@
+---
+"@transloadit/node": patch
+"@transloadit/mcp-server": patch
+"transloadit": patch
+---
+
+Handle tus upload failures without leaving duplicate internal promises unhandled.

--- a/packages/node/src/tus.ts
+++ b/packages/node/src/tus.ts
@@ -153,6 +153,12 @@ export async function sendTusRequest({
       rejectCompletion = reject
     })
 
+    // If startPromise rejects first, pMap aborts before sendTusRequest reaches the aggregate awaits
+    // below. These bookkeeping promises still need handlers so the startPromise rejection remains
+    // the single error surface.
+    uploadUrlPromise.catch(() => {})
+    completionPromise.catch(() => {})
+
     uploadUrlPromises.push(uploadUrlPromise)
     completionPromises.push(completionPromise)
 

--- a/packages/node/test/unit/tus.test.ts
+++ b/packages/node/test/unit/tus.test.ts
@@ -3,6 +3,7 @@ import type { stat as NodeStat } from 'node:fs/promises'
 import type { OnSuccessPayload, UploadOptions } from 'tus-js-client'
 
 import { PassThrough } from 'node:stream'
+import { setImmediate as delayImmediate } from 'node:timers/promises'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -269,5 +270,41 @@ describe('sendTusRequest', () => {
     ).rejects.toThrow('assembly_ssl_url is not present in the assembly status')
 
     expect(uploadCtor).not.toHaveBeenCalled()
+  })
+
+  it('does not leave bookkeeping promises unhandled when an awaited upload fails', async () => {
+    statMock.mockResolvedValue({ size: 2048 })
+
+    const uploadError = new Error('connect ETIMEDOUT 5.161.182.178:443')
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown): void => {
+      unhandledRejections.push(reason)
+    }
+
+    startBehavior = (options) => {
+      options.onError?.(uploadError)
+    }
+
+    process.on('unhandledRejection', onUnhandledRejection)
+    try {
+      await expect(
+        sendTusRequest({
+          streamsMap: {
+            failed: { path: '/tmp/failed', stream: new PassThrough() },
+          },
+          assembly: baseAssembly,
+          requestedChunkSize: 1_048_576,
+          uploadConcurrency: 1,
+          onProgress: () => {},
+        }),
+      ).rejects.toBe(uploadError)
+
+      await delayImmediate()
+      await delayImmediate()
+
+      expect(unhandledRejections).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+    }
   })
 })


### PR DESCRIPTION
## Why

API2 PagerDuty incident Q33YSSJS2BXHOF exposed that a transient tus create-upload failure can reject the caller-facing `startPromise` and also leave the SDK's internal upload URL/completion bookkeeping promises rejected without handlers. In API2 that second, duplicate rejection reached the process-wide `unhandledRejection` handler after the original `createAssembly()` failure had already been caught and reported.

## Changes

- Attach handlers to tus upload bookkeeping promises when they are created, so the caller still receives the primary upload failure while duplicate internal rejections do not become unhandled.
- Add a regression test that fails before the fix by observing two unhandled rejections after a simulated tus `onError`.
- Add patch changesets for `@transloadit/node`, `@transloadit/mcp-server`, and `transloadit` per release-coupling policy.

## Tests

- `yarn workspace @transloadit/node test:unit --run ./test/unit/tus.test.ts`
- `yarn check`

Related API2 pager PR: https://github.com/transloadit/api2/pull/8307