### PR TITLE
Harden live assembly CLI e2e tests

### DIFF
--- a/packages/node/test/e2e/cli/assemblies-create.test.ts
+++ b/packages/node/test/e2e/cli/assemblies-create.test.ts
@@ -478,41 +478,5 @@ describeLive('assemblies', { retry: 1 }, () => {
       }),
       300_000,
     )
-
-    it(
-      'should avoid opening filesystem streams during single-assembly collection',
-      testCase(async (client) => {
-        // Create multiple input files for single-assembly mode
-        const fileCount = 5
-        const infiles = await Promise.all(
-          Array.from({ length: fileCount }, (_, i) => imgPromise(`in${i}.jpg`)),
-        )
-        const steps = await stepsPromise()
-        await fsp.mkdir('out')
-
-        const output = new OutputCtl()
-        await assembliesCreate(output, client, {
-          steps,
-          inputs: infiles,
-          output: 'out',
-          singleAssembly: true, // All files in one assembly
-        })
-
-        // Verify files were processed
-        const outs = await fsp.readdir('out')
-        expect(outs.length).to.be.greaterThan(0)
-
-        // Analyze debug output to verify filesystem inputs were collected as file paths.
-        // The current implementation only opens upload streams lazily for stdin inputs,
-        // so there should be no eager "STREAM CLOSED" churn during collection.
-        const debugOutput = output.get(true) as OutputEntry[]
-        const messages = debugOutput.map((e) => String(e.msg))
-
-        const streamClosedMessages = messages.filter((m) => m.startsWith('STREAM CLOSED'))
-        expect(streamClosedMessages).to.have.lengthOf(0)
-        expect(messages).to.include(`Creating single assembly with ${fileCount} files`)
-      }),
-      300_000,
-    )
   })
 })

--- a/packages/node/test/e2e/cli/assemblies-create.test.ts
+++ b/packages/node/test/e2e/cli/assemblies-create.test.ts
@@ -19,7 +19,7 @@ const rreaddirAsync = promisify(rreaddir)
 
 const describeLive = hasTransloaditCredentials ? describe : describe.skip
 
-describeLive('assemblies', () => {
+describeLive('assemblies', { retry: 1 }, () => {
   describe('create', () => {
     const genericImg =
       'https://demos.transloadit.com/66/01604e7d0248109df8c7cc0f8daef8/snowflake.jpg'

--- a/packages/node/test/unit/cli/assemblies-create.test.ts
+++ b/packages/node/test/unit/cli/assemblies-create.test.ts
@@ -319,6 +319,47 @@ describe('assemblies create', () => {
     expect(await readFile(outputPath, 'utf8')).toBe('bundle-contents')
   })
 
+  it('collects filesystem inputs for single assemblies without opening upload streams', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const tempDir = await createTempDir('transloadit-single-files-')
+    const inputs = await Promise.all(
+      Array.from({ length: 5 }, async (_, index) => {
+        const inputPath = path.join(tempDir, `in${index}.txt`)
+        await writeFile(inputPath, `input-${index}`)
+        return inputPath
+      }),
+    )
+
+    const output = new OutputCtl()
+    const client = {
+      createAssembly: vi.fn().mockResolvedValue({ assembly_id: 'assembly-single-files' }),
+      awaitAssemblyCompletion: vi.fn().mockResolvedValue({
+        ok: 'ASSEMBLY_COMPLETED',
+        results: {},
+      }),
+    }
+
+    await create(output, client as never, {
+      inputs,
+      output: null,
+      singleAssembly: true,
+      stepsData: {
+        exported: {
+          robot: '/file/filter',
+          result: true,
+          use: ':original',
+        },
+      },
+    })
+
+    expect(client.createAssembly).toHaveBeenCalledTimes(1)
+    expect(client.createAssembly.mock.calls[0]?.[0]?.files).toEqual(
+      Object.fromEntries(inputs.map((inputPath) => [path.basename(inputPath), inputPath])),
+    )
+    expect(client.createAssembly.mock.calls[0]?.[0]?.uploads).toBeUndefined()
+  })
+
   it('runs valid inputless single-assembly steps instead of no-oping', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
 


### PR DESCRIPTION
## Why

`main` CI for the SDK release went red in the live E2E job after `@transloadit/node@4.10.8` was published. The package verify/build/unit/lockfile jobs all passed; the failing job was `test/e2e/cli/assemblies-create.test.ts`, and repeated runs failed on different live assembly-create cases.

A scheduled `main` run on `a3b9b56` failed the same live suite earlier on June 18, before the tus rejection fix and release commits, so this is not caused by the SDK tus change.

## What

- Adds the same one-retry policy to the live CLI assembly-create E2E suite that the live API E2E suite already uses.
- Moves the client-side single-assembly filesystem-stream assertion out of the live E2E suite and into the unit CLI assemblies test. The assertion now checks that filesystem inputs are passed as `files` and not eager `uploads`.

## Verification

- `corepack yarn workspace @transloadit/node test:unit --run ./test/unit/cli/assemblies-create.test.ts`
- `corepack yarn verify`
