### PR TITLE
Add Assembly Instructions compiler

### DIFF
--- a/.changeset/mcp-server-node-companion.md
+++ b/.changeset/mcp-server-node-companion.md
@@ -1,0 +1,6 @@
+---
+'@transloadit/mcp-server': patch
+'transloadit': patch
+---
+
+Release mcp-server and transloadit alongside @transloadit/node.

--- a/.changeset/prompt-assembly-compiler.md
+++ b/.changeset/prompt-assembly-compiler.md
@@ -1,0 +1,6 @@
+---
+'@transloadit/node': minor
+'@transloadit/utils': minor
+---
+
+Add a shared Assembly Instructions compiler and expose prompt-to-Assembly helpers in the Node SDK and CLI.

--- a/.changeset/prompt-assembly-compiler.md
+++ b/.changeset/prompt-assembly-compiler.md
@@ -3,4 +3,5 @@
 '@transloadit/utils': minor
 ---
 
-Add a shared Assembly Instructions compiler and expose prompt-to-Assembly helpers in the Node SDK and CLI.
+Add a shared Assembly Instructions compiler and expose prompt-to-Assembly-Instructions helpers in
+the Node SDK and CLI.

--- a/packages/node/src/Transloadit.ts
+++ b/packages/node/src/Transloadit.ts
@@ -1,5 +1,9 @@
 import type { Readable } from 'node:stream'
 
+import type {
+  CompileAssemblyInstructionsOptions,
+  CompileAssemblyInstructionsResult,
+} from '@transloadit/utils'
 import type { Delays, Headers, OptionsOfJSONResponseBody, RetryOptions } from 'got'
 
 import type { TransloaditErrorResponseBody } from './ApiError.ts'
@@ -43,6 +47,7 @@ import { access, stat } from 'node:fs/promises'
 import { basename } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 
+import { compileAssemblyInstructionsFromPrompt } from '@transloadit/utils'
 import { getSignedSmartCdnUrl, signParamsSync } from '@transloadit/utils/node'
 import debug from 'debug'
 import FormData from 'form-data'
@@ -61,6 +66,14 @@ import { lintAssemblyInstructions as lintAssemblyInstructionsInternal } from './
 import PaginationStream from './PaginationStream.ts'
 import PollingTimeoutError from './PollingTimeoutError.ts'
 import { sendTusRequest } from './tus.ts'
+
+export type {
+  CompileAssemblyInstructionsAttempt,
+  CompileAssemblyInstructionsClient,
+  CompileAssemblyInstructionsLintIssue,
+  CompileAssemblyInstructionsMessage,
+  CompileAssemblyInstructionsResult,
+} from '@transloadit/utils'
 
 export type { AssemblyStatus } from './alphalib/types/assemblyStatus.ts'
 export type {
@@ -81,6 +94,11 @@ export type {
   RobotParamHelp,
 } from './robots.ts'
 
+export {
+  buildCompileAssemblyInstructionsSystemPrompt,
+  CompileAssemblyInstructionsError,
+  parseCompileAssemblyInstructionsResponse,
+} from '@transloadit/utils'
 // See https://github.com/sindresorhus/got/tree/v11.8.6?tab=readme-ov-file#errors
 // Expose relevant errors
 export {
@@ -274,6 +292,13 @@ export interface SmartCDNUrlOptions {
   expiresAt?: number
 }
 
+export type CompileAssemblyInstructionsFromPromptOptions = Omit<
+  CompileAssemblyInstructionsOptions,
+  'client'
+> & {
+  timeout?: number
+}
+
 export type Fields = Record<string, string | number>
 
 // A special promise that lets the user immediately get the assembly ID (synchronously before the request is sent)
@@ -311,6 +336,37 @@ function checkResult<T>(result: T | { error: string }): asserts result is T {
   ) {
     throw new ApiError({ body: result }) // in this case there is no `cause` because we don't have an HTTPError
   }
+}
+
+function getResultBilledChargeUsd(result: unknown): number | undefined {
+  if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+    return undefined
+  }
+
+  if (!('meta' in result)) {
+    return undefined
+  }
+
+  const { meta } = result
+  if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
+    return undefined
+  }
+
+  if (!('billed_charge_usd' in meta)) {
+    return undefined
+  }
+
+  const { billed_charge_usd: billedChargeUsd } = meta
+  return typeof billedChargeUsd === 'number' ? billedChargeUsd : undefined
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch AI response: ${response.status} ${response.statusText}`)
+  }
+
+  return await response.json()
 }
 
 type AuthKeySecret = {
@@ -549,6 +605,56 @@ export class Transloadit {
     return await lintAssemblyInstructionsInternal({
       ...rest,
       template: template.content,
+    })
+  }
+
+  /**
+   * Compile a natural-language prompt into validated Assembly Instructions.
+   *
+   * This creates a zero-upload /ai/chat Assembly, validates the structured response,
+   * and lints the generated instructions locally before returning them.
+   */
+  async compileAssemblyInstructionsFromPrompt(
+    options: CompileAssemblyInstructionsFromPromptOptions,
+  ): Promise<CompileAssemblyInstructionsResult> {
+    const timeout = options.timeout ?? 5 * 60 * 1000
+
+    return await compileAssemblyInstructionsFromPrompt({
+      ...options,
+      mcpServerUrl: options.mcpServerUrl ?? `${this._endpoint}/mcp`,
+      client: {
+        runAssemblyInstructionsCompiler: async ({ aiStep }) => {
+          const assembly = await this.createAssembly({
+            params: {
+              steps: {
+                ai: aiStep,
+              },
+            },
+            waitForCompletion: true,
+            expectedUploads: 0,
+            timeout,
+          })
+
+          const result = assembly.results?.ai?.[0]
+          const resultUrl = result?.url
+          if (!resultUrl) {
+            throw new Error('No AI response in Assembly results.')
+          }
+
+          return {
+            response: await fetchJson(resultUrl),
+            assemblyUrl: assembly.assembly_ssl_url ?? assembly.assembly_url ?? undefined,
+            billedChargeUsd: getResultBilledChargeUsd(result),
+            usageBytes: assembly.bytes_usage ?? undefined,
+          }
+        },
+        lintAssemblyInstructions: async (instructionsJson) => {
+          const lintResult = await this.lintAssemblyInstructions({
+            assemblyInstructions: instructionsJson,
+          })
+          return lintResult.issues
+        },
+      },
     })
   }
 

--- a/packages/node/src/cli/commands/assemblies.ts
+++ b/packages/node/src/cli/commands/assemblies.ts
@@ -365,7 +365,7 @@ function createCompileOptions({
   }
 }
 
-export async function compileAssemblyInstructions(
+async function compileAssemblyInstructions(
   output: IOutputCtl,
   client: Transloadit,
   options: AssemblyInstructionsCompileOptions,

--- a/packages/node/src/cli/commands/assemblies.ts
+++ b/packages/node/src/cli/commands/assemblies.ts
@@ -3,7 +3,11 @@ import type { Readable } from 'node:stream'
 import type { StepsInput } from '../../alphalib/types/template.ts'
 import type { CreateAssemblyParams, ReplayAssemblyParams } from '../../apiTypes.ts'
 import type { LintFatalLevel } from '../../lintAssemblyInstructions.ts'
-import type { CreateAssemblyOptions, Transloadit } from '../../Transloadit.ts'
+import type {
+  CompileAssemblyInstructionsFromPromptOptions,
+  CreateAssemblyOptions,
+  Transloadit,
+} from '../../Transloadit.ts'
 import type { IOutputCtl } from '../OutputCtl.ts'
 import type { NormalizedAssemblyResultFile, NormalizedAssemblyResults } from '../resultFiles.ts'
 import type { ResultUrlRow } from '../resultUrls.ts'
@@ -44,7 +48,7 @@ import {
 import { formatAPIError, readCliInput } from '../helpers.ts'
 import { normalizeAssemblyResults } from '../resultFiles.ts'
 import { collectNormalizedResultUrlRows, printResultUrls } from '../resultUrls.ts'
-import { readStepsInputFile } from '../stepsInput.ts'
+import { parseStepsInputJson, readStepsInputFile } from '../stepsInput.ts'
 import { ensureError, isErrnoException } from '../types.ts'
 import { AuthenticatedCommand, UnauthenticatedCommand } from './BaseCommand.ts'
 
@@ -80,6 +84,14 @@ export interface AssemblyLintOptions {
   fix?: boolean
   providedInput?: string
   json?: boolean
+}
+
+export interface AssemblyCompileOptions {
+  maxAttempts?: number
+  mcpServerUrl?: string
+  model?: string
+  prompt: string
+  timeout?: number
 }
 
 function formatAssemblyReference({
@@ -323,6 +335,49 @@ export async function lint(
   }
 
   return result.success ? 0 : 1
+}
+
+function toPositiveInteger(value: number | undefined, optionName: string): number | undefined {
+  if (value == null) {
+    return undefined
+  }
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${optionName} must be a positive integer`)
+  }
+
+  return value
+}
+
+function createCompileOptions({
+  maxAttempts,
+  mcpServerUrl,
+  model,
+  prompt,
+  timeout,
+}: AssemblyCompileOptions): CompileAssemblyInstructionsFromPromptOptions {
+  return {
+    maxAttempts,
+    mcpServerUrl,
+    model,
+    prompt,
+    timeout,
+  }
+}
+
+export async function compileAssemblyInstructions(
+  output: IOutputCtl,
+  client: Transloadit,
+  options: AssemblyCompileOptions,
+): Promise<number> {
+  try {
+    const result = await client.compileAssemblyInstructionsFromPrompt(createCompileOptions(options))
+    output.print(result.instructionsJson, result)
+    return 0
+  } catch (error) {
+    output.error(formatAPIError(error))
+    return 1
+  }
 }
 
 // --- From assemblies-create.ts: Helper classes and functions ---
@@ -1658,6 +1713,64 @@ export async function create(
 }
 
 // --- Command classes ---
+export class AssembliesCompileCommand extends AuthenticatedCommand {
+  static override paths = [
+    ['assemblies', 'compile'],
+    ['assembly', 'compile'],
+    ['a', 'compile'],
+  ]
+
+  static override usage = Command.Usage({
+    category: 'Assemblies',
+    description: 'Compile a prompt into Assembly Instructions',
+    details: `
+      Compile a natural-language prompt into validated Transloadit Assembly Instructions JSON.
+    `,
+    examples: [
+      [
+        'Compile instructions',
+        'transloadit assemblies compile "resize uploaded images to 400px wide"',
+      ],
+    ],
+  })
+
+  prompt = Option.String({ required: true })
+
+  model = Option.String('--model', {
+    description: 'AI model to use for instruction compilation',
+  })
+
+  mcpServerUrl = Option.String('--mcp-server', {
+    description: 'MCP server URL used for Robot docs and instruction linting',
+  })
+
+  maxAttempts = Option.String('--max-attempts', {
+    description: 'Maximum validation attempts',
+    validator: t.applyCascade(t.isNumber(), [t.isAtLeast(1)]),
+  })
+
+  timeout = Option.String('--timeout', {
+    description: 'Compiler Assembly timeout in milliseconds',
+    validator: t.applyCascade(t.isNumber(), [t.isAtLeast(1)]),
+  })
+
+  protected async run(): Promise<number | undefined> {
+    return await compileAssemblyInstructions(this.output, this.client, {
+      maxAttempts: toPositiveInteger(
+        this.maxAttempts == null ? undefined : Number(this.maxAttempts),
+        '--max-attempts',
+      ),
+      mcpServerUrl: this.mcpServerUrl,
+      model: this.model,
+      prompt: this.prompt,
+      timeout: toPositiveInteger(
+        this.timeout == null ? undefined : Number(this.timeout),
+        '--timeout',
+      ),
+    })
+  }
+}
+
 export class AssembliesCreateCommand extends AuthenticatedCommand {
   static override paths = [
     ['assemblies', 'create'],
@@ -1758,6 +1871,135 @@ export class AssembliesCreateCommand extends AuthenticatedCommand {
     const { hasFailures, resultUrls } = await create(this.output, this.client, {
       steps: this.steps,
       template: this.template,
+      fields: fieldsMap ?? {},
+      watch: this.watch,
+      recursive: this.recursive,
+      inputs: inputList,
+      output: this.outputPath ?? null,
+      del: this.deleteAfterProcessing,
+      reprocessStale: this.reprocessStale,
+      singleAssembly: this.singleAssembly,
+      concurrency: this.concurrency == null ? undefined : Number(this.concurrency),
+    })
+    if (this.printUrls) {
+      printResultUrls(this.output, resultUrls)
+    }
+    return hasFailures ? 1 : undefined
+  }
+}
+
+export class RunCommand extends AuthenticatedCommand {
+  static override paths = [['run']]
+
+  static override usage = Command.Usage({
+    category: 'Assemblies',
+    description: 'Compile a prompt and run it as an Assembly',
+    details: `
+      Compile a natural-language prompt into Assembly Instructions, then run those instructions directly.
+    `,
+    examples: [
+      [
+        'Compile and run',
+        'transloadit run "resize uploaded images to 400px wide" -i input.jpg -o output.jpg',
+      ],
+      [
+        'Print result URLs',
+        'transloadit run "extract a waveform image from this audio" -i input.mp3 --print-urls',
+      ],
+    ],
+  })
+
+  prompt = Option.String({ required: true })
+
+  model = Option.String('--model', {
+    description: 'AI model to use for instruction compilation',
+  })
+
+  mcpServerUrl = Option.String('--mcp-server', {
+    description: 'MCP server URL used for Robot docs and instruction linting',
+  })
+
+  maxAttempts = Option.String('--max-attempts', {
+    description: 'Maximum validation attempts',
+    validator: t.applyCascade(t.isNumber(), [t.isAtLeast(1)]),
+  })
+
+  timeout = Option.String('--timeout', {
+    description: 'Compiler Assembly timeout in milliseconds',
+    validator: t.applyCascade(t.isNumber(), [t.isAtLeast(1)]),
+  })
+
+  inputs = inputPathsOption()
+
+  outputPath = Option.String('--output,-o', {
+    description: 'Specify an output file or directory',
+  })
+
+  fields = Option.Array('--field,-f', {
+    description: 'Set an Assembly field (KEY=VAL)',
+  })
+
+  watch = watchOption()
+
+  recursive = recursiveOption()
+
+  deleteAfterProcessing = deleteAfterProcessingOption()
+
+  reprocessStale = reprocessStaleOption()
+
+  singleAssembly = singleAssemblyOption()
+
+  concurrency = concurrencyOption()
+
+  printUrls = printUrlsOption()
+
+  protected async run(): Promise<number | undefined> {
+    const inputList = this.inputs ?? []
+
+    if (inputList.length === 0 && !process.stdin.isTTY) {
+      inputList.push('-')
+    }
+
+    const fieldsMap = parseTemplateFieldAssignments(this.output, this.fields)
+    if (this.fields != null && fieldsMap == null) {
+      return 1
+    }
+
+    const sharedValidationError = validateSharedFileProcessingOptions({
+      explicitInputCount: this.inputs?.length ?? 0,
+      singleAssembly: this.singleAssembly,
+      watch: this.watch,
+      watchRequiresInputsMessage: 'run --watch requires at least one input',
+    })
+    if (sharedValidationError != null) {
+      this.output.error(sharedValidationError)
+      return 1
+    }
+
+    let compiled: Awaited<ReturnType<Transloadit['compileAssemblyInstructionsFromPrompt']>>
+    try {
+      compiled = await this.client.compileAssemblyInstructionsFromPrompt(
+        createCompileOptions({
+          maxAttempts: toPositiveInteger(
+            this.maxAttempts == null ? undefined : Number(this.maxAttempts),
+            '--max-attempts',
+          ),
+          mcpServerUrl: this.mcpServerUrl,
+          model: this.model,
+          prompt: this.prompt,
+          timeout: toPositiveInteger(
+            this.timeout == null ? undefined : Number(this.timeout),
+            '--timeout',
+          ),
+        }),
+      )
+    } catch (error) {
+      this.output.error(formatAPIError(error))
+      return 1
+    }
+
+    const { hasFailures, resultUrls } = await create(this.output, this.client, {
+      stepsData: parseStepsInputJson(JSON.stringify(compiled.instructions.steps)),
       fields: fieldsMap ?? {},
       watch: this.watch,
       recursive: this.recursive,

--- a/packages/node/src/cli/commands/assemblies.ts
+++ b/packages/node/src/cli/commands/assemblies.ts
@@ -86,7 +86,7 @@ export interface AssemblyLintOptions {
   json?: boolean
 }
 
-export interface AssemblyCompileOptions {
+export interface AssemblyInstructionsCompileOptions {
   maxAttempts?: number
   mcpServerUrl?: string
   model?: string
@@ -355,7 +355,7 @@ function createCompileOptions({
   model,
   prompt,
   timeout,
-}: AssemblyCompileOptions): CompileAssemblyInstructionsFromPromptOptions {
+}: AssemblyInstructionsCompileOptions): CompileAssemblyInstructionsFromPromptOptions {
   return {
     maxAttempts,
     mcpServerUrl,
@@ -368,7 +368,7 @@ function createCompileOptions({
 export async function compileAssemblyInstructions(
   output: IOutputCtl,
   client: Transloadit,
-  options: AssemblyCompileOptions,
+  options: AssemblyInstructionsCompileOptions,
 ): Promise<number> {
   try {
     const result = await client.compileAssemblyInstructionsFromPrompt(createCompileOptions(options))
@@ -1713,15 +1713,15 @@ export async function create(
 }
 
 // --- Command classes ---
-export class AssembliesCompileCommand extends AuthenticatedCommand {
+export class AssemblyInstructionsCompileCommand extends AuthenticatedCommand {
   static override paths = [
-    ['assemblies', 'compile'],
-    ['assembly', 'compile'],
-    ['a', 'compile'],
+    ['assembly-instructions', 'compile'],
+    ['assembly-instruction', 'compile'],
+    ['instructions', 'compile'],
   ]
 
   static override usage = Command.Usage({
-    category: 'Assemblies',
+    category: 'Assembly Instructions',
     description: 'Compile a prompt into Assembly Instructions',
     details: `
       Compile a natural-language prompt into validated Transloadit Assembly Instructions JSON.
@@ -1729,7 +1729,7 @@ export class AssembliesCompileCommand extends AuthenticatedCommand {
     examples: [
       [
         'Compile instructions',
-        'transloadit assemblies compile "resize uploaded images to 400px wide"',
+        'transloadit assembly-instructions compile "resize uploaded images to 400px wide"',
       ],
     ],
   })
@@ -1893,7 +1893,7 @@ export class RunCommand extends AuthenticatedCommand {
 
   static override usage = Command.Usage({
     category: 'Assemblies',
-    description: 'Compile a prompt and run it as an Assembly',
+    description: 'Compile Assembly Instructions and run them as an Assembly',
     details: `
       Compile a natural-language prompt into Assembly Instructions, then run those instructions directly.
     `,

--- a/packages/node/src/cli/commands/index.ts
+++ b/packages/node/src/cli/commands/index.ts
@@ -3,12 +3,14 @@ import { Builtins, Cli } from 'clipanion'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { intentCommands } from '../intentCommands.ts'
 import {
+  AssembliesCompileCommand,
   AssembliesCreateCommand,
   AssembliesDeleteCommand,
   AssembliesGetCommand,
   AssembliesLintCommand,
   AssembliesListCommand,
   AssembliesReplayCommand,
+  RunCommand,
 } from './assemblies.ts'
 import { SignatureCommand, SmartCdnSignatureCommand, TokenCommand } from './auth.ts'
 import { BillsGetCommand } from './bills.ts'
@@ -41,6 +43,7 @@ export function createCli(): Cli {
   cli.register(TokenCommand)
 
   // Assemblies commands
+  cli.register(AssembliesCompileCommand)
   cli.register(AssembliesCreateCommand)
   cli.register(AssembliesListCommand)
   cli.register(AssembliesGetCommand)
@@ -64,6 +67,9 @@ export function createCli(): Cli {
 
   // Uploads commands
   cli.register(UploadCommand)
+
+  // Prompt-to-Assembly command
+  cli.register(RunCommand)
 
   // Documentation commands (offline metadata)
   cli.register(DocsRobotsListCommand)

--- a/packages/node/src/cli/commands/index.ts
+++ b/packages/node/src/cli/commands/index.ts
@@ -3,7 +3,7 @@ import { Builtins, Cli } from 'clipanion'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { intentCommands } from '../intentCommands.ts'
 import {
-  AssembliesCompileCommand,
+  AssemblyInstructionsCompileCommand,
   AssembliesCreateCommand,
   AssembliesDeleteCommand,
   AssembliesGetCommand,
@@ -43,7 +43,6 @@ export function createCli(): Cli {
   cli.register(TokenCommand)
 
   // Assemblies commands
-  cli.register(AssembliesCompileCommand)
   cli.register(AssembliesCreateCommand)
   cli.register(AssembliesListCommand)
   cli.register(AssembliesGetCommand)
@@ -68,7 +67,8 @@ export function createCli(): Cli {
   // Uploads commands
   cli.register(UploadCommand)
 
-  // Prompt-to-Assembly command
+  // Prompt-to-Assembly-Instructions commands
+  cli.register(AssemblyInstructionsCompileCommand)
   cli.register(RunCommand)
 
   // Documentation commands (offline metadata)

--- a/packages/node/src/cli/commands/index.ts
+++ b/packages/node/src/cli/commands/index.ts
@@ -3,13 +3,13 @@ import { Builtins, Cli } from 'clipanion'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { intentCommands } from '../intentCommands.ts'
 import {
-  AssemblyInstructionsCompileCommand,
   AssembliesCreateCommand,
   AssembliesDeleteCommand,
   AssembliesGetCommand,
   AssembliesLintCommand,
   AssembliesListCommand,
   AssembliesReplayCommand,
+  AssemblyInstructionsCompileCommand,
   RunCommand,
 } from './assemblies.ts'
 import { SignatureCommand, SmartCdnSignatureCommand, TokenCommand } from './auth.ts'

--- a/packages/node/test/unit/assembly-instructions-compiler.test.ts
+++ b/packages/node/test/unit/assembly-instructions-compiler.test.ts
@@ -1,0 +1,172 @@
+import type {
+  CompileAssemblyInstructionsAiStep,
+  CompileAssemblyInstructionsError,
+  CompileAssemblyInstructionsRunInput,
+  CompileAssemblyInstructionsRunResult,
+} from '@transloadit/utils'
+
+import { compileAssemblyInstructionsFromPrompt } from '@transloadit/utils'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('compileAssemblyInstructionsFromPrompt', () => {
+  it('builds an AI chat step and returns validated Assembly Instructions', async () => {
+    const aiSteps: CompileAssemblyInstructionsAiStep[] = []
+    const client = {
+      runAssemblyInstructionsCompiler: vi.fn(
+        ({
+          aiStep,
+        }: CompileAssemblyInstructionsRunInput): Promise<CompileAssemblyInstructionsRunResult> => {
+          aiSteps.push(aiStep)
+          return Promise.resolve({
+            assemblyUrl: 'https://api2.test/assemblies/123',
+            billedChargeUsd: 0.01,
+            response: {
+              message: 'Generated resize instructions.',
+              instructions: {
+                steps: {
+                  resized: {
+                    robot: '/image/resize',
+                    use: ':original',
+                    result: true,
+                    width: 400,
+                  },
+                },
+              },
+            },
+            usageBytes: 12,
+          })
+        },
+      ),
+      lintAssemblyInstructions: vi.fn(async () => []),
+    }
+
+    const result = await compileAssemblyInstructionsFromPrompt({
+      client,
+      mcpServerUrl: 'https://api2.test/mcp',
+      prompt: 'resize uploaded images to 400px wide',
+    })
+
+    expect(result).toMatchObject({
+      assemblyUrl: 'https://api2.test/assemblies/123',
+      billedChargeUsd: 0.01,
+      instructions: {
+        steps: {
+          resized: {
+            robot: '/image/resize',
+            use: ':original',
+            result: true,
+            width: 400,
+          },
+        },
+      },
+      message: 'Generated resize instructions.',
+      usageBytes: 12,
+      validationAttempts: [],
+    })
+    expect(result.instructionsJson).toContain('"steps"')
+    expect(aiSteps).toHaveLength(1)
+    expect(aiSteps[0]).toMatchObject({
+      robot: '/ai/chat',
+      result: true,
+      format: 'json',
+      interpolate: { system_message: false },
+      mcp_servers: [
+        expect.objectContaining({
+          auth: 'transloadit',
+          type: 'http',
+          url: 'https://api2.test/mcp',
+        }),
+      ],
+      messages: [{ role: 'user', content: 'resize uploaded images to 400px wide' }],
+    })
+    expect(client.lintAssemblyInstructions).toHaveBeenCalledWith(result.instructionsJson)
+  })
+
+  it('retries with validation feedback when linting finds an error', async () => {
+    const aiSteps: CompileAssemblyInstructionsAiStep[] = []
+    const client = {
+      runAssemblyInstructionsCompiler: vi.fn(
+        ({
+          aiStep,
+        }: CompileAssemblyInstructionsRunInput): Promise<CompileAssemblyInstructionsRunResult> => {
+          aiSteps.push(aiStep)
+          return Promise.resolve({
+            response: {
+              message: 'Generated instructions.',
+              instructions: {
+                steps: {
+                  resized: {
+                    robot: '/image/resize',
+                    width: 400,
+                  },
+                },
+              },
+            },
+          })
+        },
+      ),
+      lintAssemblyInstructions: vi
+        .fn()
+        .mockResolvedValueOnce([{ type: 'error', message: 'Missing use field' }])
+        .mockResolvedValueOnce([]),
+    }
+
+    const result = await compileAssemblyInstructionsFromPrompt({
+      client,
+      prompt: 'resize uploaded images to 400px wide',
+    })
+
+    expect(result.validationAttempts).toEqual([
+      expect.objectContaining({
+        attempt: 1,
+        error: 'Assembly Instructions failed linting: Missing use field',
+      }),
+    ])
+    expect(aiSteps).toHaveLength(2)
+    expect(aiSteps[1]?.messages).toEqual([
+      { role: 'user', content: 'resize uploaded images to 400px wide' },
+      expect.objectContaining({
+        role: 'user',
+        content: expect.stringContaining('Missing use field'),
+      }),
+    ])
+  })
+
+  it('throws with lint details after exhausting validation attempts', async () => {
+    const client = {
+      runAssemblyInstructionsCompiler: vi.fn(
+        (): Promise<CompileAssemblyInstructionsRunResult> =>
+          Promise.resolve({
+            response: {
+              message: 'Generated instructions.',
+              instructions: {
+                steps: {
+                  resized: {
+                    robot: '/image/resize',
+                    width: 400,
+                  },
+                },
+              },
+            },
+          }),
+      ),
+      lintAssemblyInstructions: vi.fn(async () => [
+        { type: 'error', message: 'Missing use field' },
+      ]),
+    }
+
+    await expect(
+      compileAssemblyInstructionsFromPrompt({
+        client,
+        maxAttempts: 2,
+        prompt: 'resize uploaded images to 400px wide',
+      }),
+    ).rejects.toMatchObject({
+      name: 'CompileAssemblyInstructionsError',
+      validationAttempts: [
+        expect.objectContaining({ attempt: 1 }),
+        expect.objectContaining({ attempt: 2 }),
+      ],
+    } satisfies Partial<CompileAssemblyInstructionsError>)
+  })
+})

--- a/packages/node/test/unit/cli/run-command.test.ts
+++ b/packages/node/test/unit/cli/run-command.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import OutputCtl from '../../../src/cli/OutputCtl.ts'
+import { main } from '../../../src/cli.ts'
+import { Transloadit } from '../../../src/Transloadit.ts'
+
+const tempDirs: string[] = []
+
+async function createTempDir(prefix: string): Promise<string> {
+  const tempDir = await mkdtemp(path.join(tmpdir(), prefix))
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+function resetExitCode(): void {
+  process.exitCode = undefined
+}
+
+function stubCredentials(): void {
+  vi.stubEnv('TRANSLOADIT_KEY', 'key')
+  vi.stubEnv('TRANSLOADIT_SECRET', 'secret')
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  vi.unstubAllEnvs()
+  resetExitCode()
+  await Promise.all(
+    tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true, force: true })),
+  )
+})
+
+describe('run command', () => {
+  it('compiles a prompt and submits the generated steps directly', async () => {
+    stubCredentials()
+    const tempDir = await createTempDir('transloadit-run-command-')
+    const inputPath = path.join(tempDir, 'input.jpg')
+    await writeFile(inputPath, 'image')
+
+    const compileSpy = vi
+      .spyOn(Transloadit.prototype, 'compileAssemblyInstructionsFromPrompt')
+      .mockResolvedValue({
+        instructions: {
+          steps: {
+            resized: {
+              robot: '/image/resize',
+              use: ':original',
+              result: true,
+              width: 400,
+            },
+          },
+        },
+        instructionsJson: JSON.stringify({
+          steps: {
+            resized: {
+              robot: '/image/resize',
+              use: ':original',
+              result: true,
+              width: 400,
+            },
+          },
+        }),
+        message: 'Generated resize instructions.',
+        validationAttempts: [],
+      })
+    const createAssemblySpy = vi.spyOn(Transloadit.prototype, 'createAssembly').mockResolvedValue({
+      assembly_id: 'assembly-run',
+    })
+    vi.spyOn(Transloadit.prototype, 'awaitAssemblyCompletion').mockResolvedValue({
+      ok: 'ASSEMBLY_COMPLETED',
+      results: {},
+    })
+
+    await main([
+      'run',
+      'resize uploaded images to 400px wide',
+      '--input',
+      inputPath,
+      '--field',
+      'workspace=test',
+      '--model',
+      'openai/gpt-5.5',
+      '--max-attempts',
+      '2',
+      '--timeout',
+      '10000',
+    ])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(compileSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxAttempts: 2,
+        model: 'openai/gpt-5.5',
+        prompt: 'resize uploaded images to 400px wide',
+        timeout: 10000,
+      }),
+    )
+    expect(createAssemblySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        files: {
+          in: inputPath,
+        },
+        params: {
+          fields: {
+            workspace: 'test',
+          },
+          steps: {
+            resized: {
+              robot: '/image/resize',
+              use: ':original',
+              result: true,
+              width: 400,
+            },
+          },
+        },
+      }),
+    )
+  })
+
+  it('prints compiled Assembly Instructions from assemblies compile', async () => {
+    stubCredentials()
+    const printSpy = vi.spyOn(OutputCtl.prototype, 'print').mockImplementation(() => {})
+    const compileSpy = vi
+      .spyOn(Transloadit.prototype, 'compileAssemblyInstructionsFromPrompt')
+      .mockResolvedValue({
+        instructions: {
+          steps: {
+            imported: {
+              robot: '/http/import',
+              result: true,
+              url: 'https://example.com/image.jpg',
+            },
+          },
+        },
+        instructionsJson: JSON.stringify({
+          steps: {
+            imported: {
+              robot: '/http/import',
+              result: true,
+              url: 'https://example.com/image.jpg',
+            },
+          },
+        }),
+        message: 'Generated import instructions.',
+        validationAttempts: [],
+      })
+
+    await main([
+      'assemblies',
+      'compile',
+      'import https://example.com/image.jpg',
+      '--mcp-server',
+      'https://api2.test/mcp',
+    ])
+
+    expect(process.exitCode).toBeUndefined()
+    expect(compileSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcpServerUrl: 'https://api2.test/mcp',
+        prompt: 'import https://example.com/image.jpg',
+      }),
+    )
+    expect(printSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"steps"'),
+      expect.objectContaining({
+        message: 'Generated import instructions.',
+      }),
+    )
+  })
+})

--- a/packages/node/test/unit/cli/run-command.test.ts
+++ b/packages/node/test/unit/cli/run-command.test.ts
@@ -121,7 +121,7 @@ describe('run command', () => {
     )
   })
 
-  it('prints compiled Assembly Instructions from assemblies compile', async () => {
+  it('prints compiled Assembly Instructions from assembly-instructions compile', async () => {
     stubCredentials()
     const printSpy = vi.spyOn(OutputCtl.prototype, 'print').mockImplementation(() => {})
     const compileSpy = vi
@@ -150,7 +150,7 @@ describe('run command', () => {
       })
 
     await main([
-      'assemblies',
+      'assembly-instructions',
       'compile',
       'import https://example.com/image.jpg',
       '--mcp-server',

--- a/packages/utils/src/assemblyInstructionsCompiler.ts
+++ b/packages/utils/src/assemblyInstructionsCompiler.ts
@@ -1,0 +1,377 @@
+export const COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_MODEL = 'openai/gpt-5.5'
+export const COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_REASONING_EFFORT = 'medium'
+export const COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_MAX_ATTEMPTS = 3
+
+export const COMPILE_ASSEMBLY_INSTRUCTIONS_MCP_ALLOWED_TOOLS = [
+  'transloadit_get_robot_help',
+  'transloadit_lint_assembly_instructions',
+  'transloadit_list_robots',
+] as const
+
+export type CompileAssemblyInstructionsMessage = {
+  role: 'assistant' | 'user'
+  content: string
+}
+
+export type CompileAssemblyInstructionsMcpServer =
+  | string
+  | {
+      type: string
+      url: string
+      headers?: Record<string, string>
+      auth?: string
+      allowed_tools?: string | string[]
+    }
+
+export type CompileAssemblyInstructionsLintIssue = {
+  type?: string
+  code?: string
+  message?: string
+  summary?: string
+  desc?: string
+}
+
+export type CompileAssemblyInstructionsAiStep = {
+  robot: '/ai/chat'
+  result: true
+  model: string
+  reasoning_effort: string
+  test_credentials: true
+  format: 'json'
+  schema: string
+  system_message: string
+  interpolate: {
+    system_message: false
+  }
+  messages: CompileAssemblyInstructionsMessage[]
+  mcp_servers?: CompileAssemblyInstructionsMcpServer[]
+}
+
+export type CompileAssemblyInstructionsRunInput = {
+  aiStep: CompileAssemblyInstructionsAiStep
+}
+
+export type CompileAssemblyInstructionsRunResult = {
+  response: unknown
+  assemblyUrl?: string
+  billedChargeUsd?: number
+  usageBytes?: number
+}
+
+export type CompileAssemblyInstructionsClient = {
+  runAssemblyInstructionsCompiler(
+    input: CompileAssemblyInstructionsRunInput,
+  ): Promise<CompileAssemblyInstructionsRunResult>
+  lintAssemblyInstructions(
+    instructionsJson: string,
+  ): Promise<CompileAssemblyInstructionsLintIssue[]>
+}
+
+export type CompileAssemblyInstructionsResponse = {
+  message: string
+  instructions?: {
+    steps: Record<string, unknown>
+  }
+}
+
+export type CompileAssemblyInstructionsAttempt = {
+  attempt: number
+  error: string
+  generatedInstructions?: string
+  lintIssues?: CompileAssemblyInstructionsLintIssue[]
+}
+
+export type CompileAssemblyInstructionsResult = {
+  assemblyUrl?: string
+  billedChargeUsd?: number
+  instructions: {
+    steps: Record<string, unknown>
+  }
+  instructionsJson: string
+  message: string
+  usageBytes?: number
+  validationAttempts: CompileAssemblyInstructionsAttempt[]
+}
+
+export type CompileAssemblyInstructionsOptions = {
+  client: CompileAssemblyInstructionsClient
+  docs?: string
+  indent?: number
+  maxAttempts?: number
+  mcpServerUrl?: string
+  mcpServers?: CompileAssemblyInstructionsMcpServer[]
+  messages?: CompileAssemblyInstructionsMessage[]
+  model?: string
+  prompt: string
+  reasoningEffort?: string
+  systemPrompt?: string
+}
+
+export class CompileAssemblyInstructionsError extends Error {
+  generatedInstructions?: string
+  lintIssues?: CompileAssemblyInstructionsLintIssue[]
+  validationAttempts: CompileAssemblyInstructionsAttempt[]
+
+  constructor(
+    message: string,
+    opts: {
+      cause?: unknown
+      generatedInstructions?: string
+      lintIssues?: CompileAssemblyInstructionsLintIssue[]
+      validationAttempts?: CompileAssemblyInstructionsAttempt[]
+    } = {},
+  ) {
+    super(message, opts.cause === undefined ? undefined : { cause: opts.cause })
+    this.name = 'CompileAssemblyInstructionsError'
+    this.generatedInstructions = opts.generatedInstructions
+    this.lintIssues = opts.lintIssues
+    this.validationAttempts = opts.validationAttempts ?? []
+  }
+}
+
+export const COMPILE_ASSEMBLY_INSTRUCTIONS_RESPONSE_JSON_SCHEMA = JSON.stringify({
+  type: 'object',
+  additionalProperties: false,
+  required: ['message'],
+  properties: {
+    message: {
+      type: 'string',
+      description:
+        'A brief explanation or conversational reply. Mention assumptions, missing credentials, or placeholders when relevant.',
+    },
+    instructions: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['steps'],
+      properties: {
+        steps: {
+          type: 'object',
+          additionalProperties: true,
+          description:
+            'The complete Transloadit Assembly Instructions steps object. Always include every step, not just changed parts.',
+        },
+      },
+    },
+  },
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export function buildCompileAssemblyInstructionsSystemPrompt({
+  docs,
+}: {
+  docs?: string
+} = {}): string {
+  const docsSuffix = docs?.trim() ? `\n\n${docs.trim()}` : ''
+
+  return `You are a Transloadit Assembly Instructions generator. Your sole purpose is to help users create and modify valid Transloadit Assembly Instructions JSON.
+
+IMPORTANT CONSTRAINTS:
+- You MUST only discuss Transloadit Assembly Instructions. Politely decline any other requests.
+- Return Assembly Instructions, not Templates. A Template is only a possible place where these instructions may later be saved.
+- The instructions must have a top-level "steps" object where each step has a "robot" field referencing a valid Transloadit Robot (for example, "/image/resize", "/s3/store", "/video/encode").
+- Steps that process output from other steps must include a "use" field referencing the source step name prefixed with ":" (for example, "use": ":resized").
+- The first step that handles direct uploads should use "robot": "/upload/handle".
+- Do not send, request, or infer file contents unless the user explicitly asks for content-aware processing.
+
+WORKFLOW:
+1. Understand what the user wants to achieve.
+2. Use the bundled Transloadit documentation and MCP tools to choose the right Robots and parameters.
+3. Use the transloadit_list_robots tool to find relevant Robots if unsure which Robot to use.
+4. Use the transloadit_get_robot_help tool to get parameter details for specific Robots.
+5. Generate the Assembly Instructions JSON.
+6. Use the transloadit_lint_assembly_instructions tool to validate your output. Pass the full JSON including the "steps" wrapper.
+7. If linting reports errors, fix them and lint again until it passes.
+8. Return the final validated JSON with a brief explanation.
+
+WHEN ADAPTING EXISTING INSTRUCTIONS:
+- The user's current Assembly Instructions JSON may be included as context.
+- The user's current lint issues may be included when relevant.
+- Preserve existing steps unless the user explicitly asks to remove or replace them.
+- Preserve all template expressions (\`\${...}\`) and field names exactly as written.
+- Never resolve existing template expressions like \`\${fields.input}\` or \`\${file.url_name}\` to concrete values or empty strings.
+- If the user asks for a default or fallback for an existing field-driven expression, preserve the dynamic expression and prefer JavaScript fallback syntax such as \`\${fields.w || 400}\` over replacing it with a fixed number.${docsSuffix}`
+}
+
+export function parseCompileAssemblyInstructionsResponse(
+  value: unknown,
+): CompileAssemblyInstructionsResponse {
+  if (!isRecord(value)) {
+    throw new CompileAssemblyInstructionsError('AI response was not a JSON object.')
+  }
+
+  if (typeof value.message !== 'string') {
+    throw new CompileAssemblyInstructionsError('AI response was missing a string message.')
+  }
+
+  if (value.instructions === undefined) {
+    return { message: value.message }
+  }
+
+  if (!isRecord(value.instructions)) {
+    throw new CompileAssemblyInstructionsError('AI response instructions must be an object.')
+  }
+
+  const { steps } = value.instructions
+  if (!isRecord(steps)) {
+    throw new CompileAssemblyInstructionsError(
+      'AI response instructions must include a steps object.',
+    )
+  }
+
+  return {
+    message: value.message,
+    instructions: { steps },
+  }
+}
+
+function getIssueMessage(issue: CompileAssemblyInstructionsLintIssue): string {
+  return issue.summary ?? issue.message ?? issue.desc ?? issue.code ?? 'Unknown lint issue'
+}
+
+function getBlockingLintIssues(
+  lintIssues: CompileAssemblyInstructionsLintIssue[],
+): CompileAssemblyInstructionsLintIssue[] {
+  return lintIssues.filter((lintIssue) => lintIssue.type === 'error')
+}
+
+function createMcpServers(
+  options: CompileAssemblyInstructionsOptions,
+): CompileAssemblyInstructionsMcpServer[] {
+  if (options.mcpServers) {
+    return options.mcpServers
+  }
+
+  if (!options.mcpServerUrl) {
+    return []
+  }
+
+  return [
+    {
+      type: 'http',
+      url: options.mcpServerUrl,
+      auth: 'transloadit',
+      allowed_tools: [...COMPILE_ASSEMBLY_INSTRUCTIONS_MCP_ALLOWED_TOOLS],
+    },
+  ]
+}
+
+function appendRetryInstruction(
+  messages: CompileAssemblyInstructionsMessage[],
+  lastError: string | null,
+): CompileAssemblyInstructionsMessage[] {
+  if (!lastError) {
+    return messages
+  }
+
+  return [
+    ...messages,
+    {
+      role: 'user',
+      content: `The previous response failed validation: ${lastError}\n\nPlease fix the Assembly Instructions and try again.`,
+    },
+  ]
+}
+
+function createAiStep(
+  options: CompileAssemblyInstructionsOptions,
+  messages: CompileAssemblyInstructionsMessage[],
+): CompileAssemblyInstructionsAiStep {
+  const mcpServers = createMcpServers(options)
+  const aiStep: CompileAssemblyInstructionsAiStep = {
+    robot: '/ai/chat',
+    result: true,
+    model: options.model ?? COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_MODEL,
+    reasoning_effort:
+      options.reasoningEffort ?? COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_REASONING_EFFORT,
+    test_credentials: true,
+    format: 'json',
+    schema: COMPILE_ASSEMBLY_INSTRUCTIONS_RESPONSE_JSON_SCHEMA,
+    system_message:
+      options.systemPrompt ?? buildCompileAssemblyInstructionsSystemPrompt({ docs: options.docs }),
+    interpolate: {
+      system_message: false,
+    },
+    messages,
+  }
+
+  if (mcpServers.length > 0) {
+    aiStep.mcp_servers = mcpServers
+  }
+
+  return aiStep
+}
+
+export async function compileAssemblyInstructionsFromPrompt(
+  options: CompileAssemblyInstructionsOptions,
+): Promise<CompileAssemblyInstructionsResult> {
+  const baseMessages: CompileAssemblyInstructionsMessage[] = [
+    ...(options.messages ?? []),
+    { role: 'user', content: options.prompt },
+  ]
+  const maxAttempts = options.maxAttempts ?? COMPILE_ASSEMBLY_INSTRUCTIONS_DEFAULT_MAX_ATTEMPTS
+  const validationAttempts: CompileAssemblyInstructionsAttempt[] = []
+  let lastError: string | null = null
+  let lastGeneratedInstructions: string | undefined
+  let lastLintIssues: CompileAssemblyInstructionsLintIssue[] | undefined
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const messages = appendRetryInstruction(baseMessages, lastError)
+    const runResult = await options.client.runAssemblyInstructionsCompiler({
+      aiStep: createAiStep(options, messages),
+    })
+    let response: CompileAssemblyInstructionsResponse
+    try {
+      response = parseCompileAssemblyInstructionsResponse(runResult.response)
+    } catch (error) {
+      if (!(error instanceof CompileAssemblyInstructionsError)) {
+        throw error
+      }
+
+      lastError = error.message
+      validationAttempts.push({ attempt, error: lastError })
+      continue
+    }
+
+    if (!response.instructions) {
+      lastError = 'AI response did not include Assembly Instructions.'
+      validationAttempts.push({ attempt, error: lastError })
+      continue
+    }
+
+    const instructionsJson = JSON.stringify(response.instructions, null, options.indent ?? 2)
+    const lintIssues = await options.client.lintAssemblyInstructions(instructionsJson)
+    const blockingLintIssues = getBlockingLintIssues(lintIssues)
+
+    if (blockingLintIssues.length === 0) {
+      return {
+        assemblyUrl: runResult.assemblyUrl,
+        billedChargeUsd: runResult.billedChargeUsd,
+        instructions: response.instructions,
+        instructionsJson,
+        message: response.message,
+        usageBytes: runResult.usageBytes,
+        validationAttempts,
+      }
+    }
+
+    lastGeneratedInstructions = instructionsJson
+    lastLintIssues = blockingLintIssues
+    lastError = `Assembly Instructions failed linting: ${blockingLintIssues
+      .map(getIssueMessage)
+      .join('; ')}`
+    validationAttempts.push({
+      attempt,
+      error: lastError,
+      generatedInstructions: instructionsJson,
+      lintIssues: blockingLintIssues,
+    })
+  }
+
+  throw new CompileAssemblyInstructionsError(`Failed after ${maxAttempts} attempts.`, {
+    generatedInstructions: lastGeneratedInstructions,
+    lintIssues: lastLintIssues,
+    validationAttempts,
+  })
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,7 @@
 export type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha384'
 
+export * from './assemblyInstructionsCompiler.ts'
+
 const algorithmMap = {
   sha1: 'SHA-1',
   sha256: 'SHA-256',


### PR DESCRIPTION
Why:

transloadit/api2#8211 needs the console and CLI to share the same prompt-to-Assembly-Instructions compiler without treating generated instructions as Templates. This puts the compiler contract in `@transloadit/utils`, exposes it through the Node SDK, and adds CLI entry points for compiling and running raw Assembly Instructions.

What:

- add a shared prompt-to-Assembly-Instructions compiler in `@transloadit/utils`
- expose `Transloadit.compileAssemblyInstructionsFromPrompt()` with a client-shaped adapter around `/ai/chat`
- add `transloadit assembly-instructions compile` and `transloadit run`
- cover compiler retry behavior and CLI raw-steps submission with unit tests
- add a changeset for `@transloadit/node` and `@transloadit/utils`

Validation:

- `yarn tsc:utils`
- `yarn tsc:node`
- `../../node_modules/.bin/vitest run ./test/unit/assembly-instructions-compiler.test.ts ./test/unit/cli/run-command.test.ts`
- live CLI: `node packages/node/dist/cli.js assemblies compile ... --max-attempts 2 --timeout 300000` before command rename; current tested command path is `assembly-instructions compile`
- live CLI: `node packages/node/dist/cli.js run ... --input packages/node/test/e2e/fixtures/sample.jpg --print-urls --max-attempts 3 --timeout 300000`
