### PR TITLE
Run Claude automation on Opus 4.8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-4-8

--- a/docs/prompts/2026-07-22-prefer-opus-48.md
+++ b/docs/prompts/2026-07-22-prefer-opus-48.md
@@ -1,0 +1,14 @@
+# Prefer Opus 4.8 for Anthropic workloads
+
+Why: Fable 5 spend is higher than intended for repository automation. Keep Fable available in the
+public model capability map, but run the Node SDK Claude GitHub workflow with Opus 4.8.
+
+## Checklist
+
+- [x] Move the Claude GitHub workflow from Fable 5 to Opus 4.8.
+- [x] Preserve Fable 5 and Sonnet 5 public model support.
+- [x] Keep image description on Sonnet 5.
+- [x] Run council review and reconcile its findings: no issues found.
+- [x] Run `corepack yarn check`: passed.
+- [ ] Confirm all required CI checks pass.
+- [ ] Confirm there are no unresolved review comments.

--- a/docs/prompts/2026-07-22-prefer-opus-48.md
+++ b/docs/prompts/2026-07-22-prefer-opus-48.md
@@ -10,5 +10,5 @@ public model capability map, but run the Node SDK Claude GitHub workflow with Op
 - [x] Keep image description on Sonnet 5.
 - [x] Run council review and reconcile its findings: no issues found.
 - [x] Run `corepack yarn check`: passed.
-- [ ] Confirm all required CI checks pass.
-- [ ] Confirm there are no unresolved review comments.
+- [x] Confirm all required CI checks pass.
+- [x] Confirm there are no unresolved review comments.


### PR DESCRIPTION
Why: Fable 5 spend is higher than intended for repository automation. Public Fable support and the Sonnet 5 image-description default should remain unchanged.

## What changed

- run the `@claude` GitHub workflow on Opus 4.8
- preserve Fable 5 and Sonnet 5 model capabilities
- keep image description on Sonnet 5

## Validation

- council review: no issues found
- `corepack yarn check`: passed