### PR TITLE
Add Claude Opus 5 support

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,8 +75,8 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-5

--- a/packages/node/src/alphalib/types/robots/ai-chat.ts
+++ b/packages/node/src/alphalib/types/robots/ai-chat.ts
@@ -543,6 +543,7 @@ export const MODEL_CAPABILITIES: Record<string, { pdf: boolean; image: boolean }
   'anthropic/claude-4-sonnet-20250514': { pdf: true, image: true },
   'anthropic/claude-sonnet-4-20250514': { pdf: true, image: true },
   'anthropic/claude-opus-4-8': { pdf: true, image: true },
+  'anthropic/claude-opus-5': { pdf: true, image: true },
   'anthropic/claude-4-opus-20250514': { pdf: true, image: true },
   'anthropic/claude-opus-4-20250514': { pdf: true, image: true },
   'anthropic/claude-sonnet-4-5': { pdf: true, image: true },


### PR DESCRIPTION
Why: downstream projects need the public model capability map and repository automation to recognize Opus 5 before they can adopt it safely.

Changes:
- expose Opus 5 in the AI chat model capabilities
- move the Claude workflow to Opus 5
- keep image description on Sonnet 5 and assembly compilation at medium reasoning

Validation:
- yarn check
- council review completed

Sister PRs:
- https://github.com/transloadit/content/pull/5405
- https://github.com/transloadit/api2/pull/8541
- https://github.com/transloadit/accounting/pull/270
- https://github.com/transloadit/botty/pull/199
- https://github.com/transloadit/team-internals/pull/575
- https://github.com/kvz/clawfleet/pull/15
- https://github.com/kvz/arkivz/pull/142
- https://github.com/kvz/dotfiles/pull/16