### PR TITLE
Add MCP documentation retrieval tools

### DIFF
--- a/.changeset/quiet-tools-search.md
+++ b/.changeset/quiet-tools-search.md
@@ -1,0 +1,5 @@
+---
+'@transloadit/mcp-server': minor
+---
+
+Add read-only tools for searching and retrieving public Transloadit documentation as Markdown.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -244,6 +244,8 @@ npx -y @transloadit/mcp-server stdio
 ## Tool surface
 
 - `transloadit_lint_assembly_instructions`
+- `transloadit_search_docs` (read-only; no account credentials required)
+- `transloadit_get_doc` (read-only; no account credentials required)
 - `transloadit_create_assembly`
 - `transloadit_get_assembly_status`
 - `transloadit_wait_for_assembly`
@@ -255,6 +257,10 @@ npx -y @transloadit/mcp-server stdio
 
 - `include_builtin`: `all`, `latest`, `exclusively-all`, `exclusively-latest`
 - `include_content`: include parsed `steps` in each template item
+
+Use `transloadit_search_docs` to discover a small set of relevant pages, then
+`transloadit_get_doc` to retrieve one page as bounded Markdown. Documentation tools only fetch
+public paths on `transloadit.com`; they never use or return Transloadit account credentials.
 
 ## Input files
 

--- a/packages/mcp-server/src/docs.ts
+++ b/packages/mcp-server/src/docs.ts
@@ -14,8 +14,22 @@ export interface DocsPage {
 }
 
 const docsOrigin = 'https://transloadit.com'
-const docsIndexUrl = `${docsOrigin}/llms.txt`
 const docsFetchTimeoutMs = 10_000
+const docsIndexMaxChars = 500_000
+const rootDocsIndexUrl = `${docsOrigin}/llms.txt`
+const docsIndexUrls: Record<DocsScope, readonly string[]> = {
+  all: [
+    `${docsOrigin}/docs/llms.txt`,
+    `${docsOrigin}/docs/api/llms.txt`,
+    `${docsOrigin}/docs/faq/llms.txt`,
+    `${docsOrigin}/docs/robots/llms.txt`,
+    `${docsOrigin}/docs/sdks/llms.txt`,
+  ],
+  api: [`${docsOrigin}/docs/api/llms.txt`],
+  faq: [`${docsOrigin}/docs/faq/llms.txt`],
+  robots: [`${docsOrigin}/docs/robots/llms.txt`],
+  sdks: [`${docsOrigin}/docs/sdks/llms.txt`],
+}
 const markdownLinkPattern = /^- \[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?$/u
 
 function normalizeDocsUrl(value: string): URL | undefined {
@@ -23,18 +37,57 @@ function normalizeDocsUrl(value: string): URL | undefined {
 
   const url = new URL(value, docsOrigin)
   if (url.origin !== docsOrigin) return
+  url.hash = ''
+  url.search = ''
   if (url.pathname === '/llms.txt') return url
   if (!url.pathname.startsWith('/docs/')) return
 
   if (!url.pathname.endsWith('.md') && !url.pathname.endsWith('.txt')) {
     url.pathname = `${url.pathname.replace(/\/$/u, '')}.md`
   }
-  url.hash = ''
-  url.search = ''
   return url
 }
 
-async function fetchDocsText(url: string, fetcher: typeof fetch): Promise<string> {
+interface DocsTextResponse {
+  text: string
+  truncated: boolean
+}
+
+async function readBoundedResponseText(
+  response: Response,
+  maxChars: number,
+): Promise<DocsTextResponse> {
+  if (response.body === null) {
+    return { text: '', truncated: false }
+  }
+
+  const decoder = new TextDecoder()
+  const reader = response.body.getReader()
+  let text = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      text += decoder.decode()
+      return {
+        text: text.slice(0, maxChars),
+        truncated: text.length > maxChars,
+      }
+    }
+
+    text += decoder.decode(value, { stream: true })
+    if (text.length <= maxChars) continue
+
+    await reader.cancel()
+    return { text: text.slice(0, maxChars), truncated: true }
+  }
+}
+
+async function fetchDocsText(
+  url: string,
+  maxChars: number,
+  fetcher: typeof fetch,
+): Promise<DocsTextResponse> {
   const response = await fetcher(url, {
     headers: { Accept: 'text/markdown, text/plain;q=0.9' },
     signal: AbortSignal.timeout(docsFetchTimeoutMs),
@@ -42,7 +95,25 @@ async function fetchDocsText(url: string, fetcher: typeof fetch): Promise<string
   if (!response.ok) {
     throw new Error(`Documentation request failed with HTTP ${response.status}.`)
   }
-  return response.text()
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('text/markdown') && !contentType.includes('text/plain')) {
+    throw new Error(`Documentation request returned unsupported content type: ${contentType}.`)
+  }
+  return readBoundedResponseText(response, maxChars)
+}
+
+async function fetchSearchIndexes(
+  scope: DocsScope,
+  fetcher: typeof fetch,
+): Promise<DocsTextResponse[]> {
+  try {
+    return await Promise.all(
+      docsIndexUrls[scope].map((url) => fetchDocsText(url, docsIndexMaxChars, fetcher)),
+    )
+  } catch {
+    // Keep search available if the MCP package deploys before the scoped content routes.
+    return [await fetchDocsText(rootDocsIndexUrl, docsIndexMaxChars, fetcher)]
+  }
 }
 
 function parseIndex(index: string): DocsSearchResult[] {
@@ -86,7 +157,11 @@ export async function searchTransloaditDocs(
   fetcher: typeof fetch = fetch,
 ): Promise<DocsSearchResult[]> {
   const terms = query.toLowerCase().split(/\s+/u).filter(Boolean)
-  const index = await fetchDocsText(docsIndexUrl, fetcher)
+  const indexResponses = await fetchSearchIndexes(scope, fetcher)
+  if (indexResponses.some(({ truncated }) => truncated)) {
+    throw new Error('A documentation index exceeded the maximum supported size.')
+  }
+  const index = indexResponses.map(({ text }) => text).join('\n')
 
   return parseIndex(index)
     .filter((result) => matchesScope(result, scope))
@@ -109,12 +184,12 @@ export async function getTransloaditDoc(
   const url = normalizeDocsUrl(pathOrUrl)
   if (url === undefined) return
 
-  const markdown = await fetchDocsText(url.toString(), fetcher)
+  const { text: markdown, truncated } = await fetchDocsText(url.toString(), maxChars, fetcher)
   const title = markdown.match(/^#\s+(.+)$/mu)?.[1] ?? url.pathname
   return {
     title,
     url: url.toString(),
-    markdown: markdown.slice(0, maxChars),
-    truncated: markdown.length > maxChars,
+    markdown,
+    truncated,
   }
 }

--- a/packages/mcp-server/src/docs.ts
+++ b/packages/mcp-server/src/docs.ts
@@ -1,0 +1,120 @@
+export type DocsScope = 'all' | 'api' | 'faq' | 'robots' | 'sdks'
+
+export interface DocsSearchResult {
+  title: string
+  url: string
+  description?: string
+}
+
+export interface DocsPage {
+  title: string
+  url: string
+  markdown: string
+  truncated: boolean
+}
+
+const docsOrigin = 'https://transloadit.com'
+const docsIndexUrl = `${docsOrigin}/llms.txt`
+const docsFetchTimeoutMs = 10_000
+const markdownLinkPattern = /^- \[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?$/u
+
+function normalizeDocsUrl(value: string): URL | undefined {
+  if (!URL.canParse(value, docsOrigin)) return
+
+  const url = new URL(value, docsOrigin)
+  if (url.origin !== docsOrigin) return
+  if (url.pathname === '/llms.txt') return url
+  if (!url.pathname.startsWith('/docs/')) return
+
+  if (!url.pathname.endsWith('.md') && !url.pathname.endsWith('.txt')) {
+    url.pathname = `${url.pathname.replace(/\/$/u, '')}.md`
+  }
+  url.hash = ''
+  url.search = ''
+  return url
+}
+
+async function fetchDocsText(url: string, fetcher: typeof fetch): Promise<string> {
+  const response = await fetcher(url, {
+    headers: { Accept: 'text/markdown, text/plain;q=0.9' },
+    signal: AbortSignal.timeout(docsFetchTimeoutMs),
+  })
+  if (!response.ok) {
+    throw new Error(`Documentation request failed with HTTP ${response.status}.`)
+  }
+  return response.text()
+}
+
+function parseIndex(index: string): DocsSearchResult[] {
+  const results: DocsSearchResult[] = []
+  for (const line of index.split('\n')) {
+    const match = markdownLinkPattern.exec(line.trim())
+    if (match === null) continue
+
+    const [, title, rawUrl, description] = match
+    if (title === undefined || rawUrl === undefined) continue
+    const url = normalizeDocsUrl(rawUrl)
+    if (url === undefined || !url.pathname.startsWith('/docs/')) continue
+    results.push({ title, url: url.toString(), description })
+  }
+  return results
+}
+
+function matchesScope(result: DocsSearchResult, scope: DocsScope): boolean {
+  if (scope === 'all') return true
+  return new URL(result.url).pathname.startsWith(`/docs/${scope}/`)
+}
+
+function getSearchScore(result: DocsSearchResult, terms: string[]): number {
+  const title = result.title.toLowerCase()
+  const description = result.description?.toLowerCase() ?? ''
+  const url = result.url.toLowerCase()
+
+  return terms.reduce((score, term) => {
+    if (title.includes(term)) return score + 5
+    if (description.includes(term)) return score + 2
+    if (url.includes(term)) return score + 1
+    return score
+  }, 0)
+}
+
+/** Search the public Transloadit documentation index without requiring account credentials. */
+export async function searchTransloaditDocs(
+  query: string,
+  scope: DocsScope,
+  limit: number,
+  fetcher: typeof fetch = fetch,
+): Promise<DocsSearchResult[]> {
+  const terms = query.toLowerCase().split(/\s+/u).filter(Boolean)
+  const index = await fetchDocsText(docsIndexUrl, fetcher)
+
+  return parseIndex(index)
+    .filter((result) => matchesScope(result, scope))
+    .map((result) => ({ result, score: getSearchScore(result, terms) }))
+    .filter(({ score }) => score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.result.title.localeCompare(right.result.title),
+    )
+    .slice(0, limit)
+    .map(({ result }) => result)
+}
+
+/** Fetch one public Transloadit documentation page as bounded Markdown. */
+export async function getTransloaditDoc(
+  pathOrUrl: string,
+  maxChars: number,
+  fetcher: typeof fetch = fetch,
+): Promise<DocsPage | undefined> {
+  const url = normalizeDocsUrl(pathOrUrl)
+  if (url === undefined) return
+
+  const markdown = await fetchDocsText(url.toString(), fetcher)
+  const title = markdown.match(/^#\s+(.+)$/mu)?.[1] ?? url.pathname
+  return {
+    title,
+    url: url.toString(),
+    markdown: markdown.slice(0, maxChars),
+    truncated: markdown.length > maxChars,
+  }
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -19,6 +19,7 @@ import {
 import { z } from 'zod'
 
 import packageJson from '../package.json' with { type: 'json' }
+import { getTransloaditDoc, searchTransloaditDocs } from './docs.ts'
 import { extractBearerToken } from './http-helpers.ts'
 
 export type TransloaditMcpServerOptions = {
@@ -54,7 +55,52 @@ type ToolExtra = {
   }
 }
 
+const toolMessageSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  hint: z.string().optional(),
+  path: z.string().optional(),
+})
+
 const maxBase64Bytes = 512_000
+
+const searchDocsInputSchema = z.object({
+  query: z.string().min(2),
+  scope: z.enum(['all', 'api', 'faq', 'robots', 'sdks']).default('all'),
+  limit: z.number().int().min(1).max(20).default(8),
+})
+
+const searchDocsOutputSchema = z.object({
+  status: z.enum(['ok', 'error']),
+  results: z
+    .array(
+      z.object({
+        title: z.string(),
+        url: z.string(),
+        description: z.string().optional(),
+      }),
+    )
+    .optional(),
+  errors: z.array(toolMessageSchema).optional(),
+})
+
+const getDocInputSchema = z.object({
+  path_or_url: z.string().min(1),
+  max_chars: z.number().int().min(1_000).max(100_000).default(50_000),
+})
+
+const getDocOutputSchema = z.object({
+  status: z.enum(['ok', 'error']),
+  document: z
+    .object({
+      title: z.string(),
+      url: z.string(),
+      markdown: z.string(),
+      truncated: z.boolean(),
+    })
+    .optional(),
+  errors: z.array(toolMessageSchema).optional(),
+})
 
 type LintAssemblyInstructionsInput = Parameters<Transloadit['lintAssemblyInstructions']>[0]
 
@@ -63,13 +109,6 @@ const lintIssueSchema = z.object({
   message: z.string(),
   severity: z.enum(['error', 'warning']),
   hint: z.string().optional(),
-})
-
-const toolMessageSchema = z.object({
-  code: z.string(),
-  message: z.string(),
-  hint: z.string().optional(),
-  path: z.string().optional(),
 })
 
 const listRobotsInputSchema = z.object({
@@ -616,6 +655,56 @@ export const createTransloaditMcpServer = (
   })
 
   // Builtin templates supersede the old golden template tool; no legacy alias by design.
+  server.registerTool(
+    'transloadit_search_docs',
+    {
+      title: 'Search Transloadit documentation',
+      description:
+        'Search the public Transloadit documentation index. This read-only tool does not require account credentials.',
+      inputSchema: searchDocsInputSchema,
+      outputSchema: searchDocsOutputSchema,
+    },
+    async ({ query, scope, limit }) => {
+      try {
+        const results = await searchTransloaditDocs(query, scope, limit)
+        return buildToolResponse({ status: 'ok', results })
+      } catch {
+        return buildToolError(
+          'mcp_docs_unavailable',
+          'The Transloadit documentation index is temporarily unavailable.',
+        )
+      }
+    },
+  )
+
+  server.registerTool(
+    'transloadit_get_doc',
+    {
+      title: 'Get Transloadit documentation',
+      description:
+        'Fetch one public Transloadit documentation page as Markdown. Accepts a /docs path or transloadit.com docs URL.',
+      inputSchema: getDocInputSchema,
+      outputSchema: getDocOutputSchema,
+    },
+    async ({ path_or_url, max_chars }) => {
+      try {
+        const document = await getTransloaditDoc(path_or_url, max_chars)
+        if (document === undefined) {
+          return buildToolError(
+            'mcp_invalid_docs_url',
+            'Provide a public path under /docs or a transloadit.com documentation URL.',
+          )
+        }
+        return buildToolResponse({ status: 'ok', document })
+      } catch {
+        return buildToolError(
+          'mcp_docs_unavailable',
+          'The requested Transloadit documentation page is temporarily unavailable.',
+        )
+      }
+    },
+  )
+
   server.registerTool(
     'transloadit_lint_assembly_instructions',
     {

--- a/packages/mcp-server/test/e2e/stdio.test.ts
+++ b/packages/mcp-server/test/e2e/stdio.test.ts
@@ -20,6 +20,8 @@ describe('mcp-server stdio', { timeout: 20000 }, () => {
     const toolNames = toolsResult.tools.map((tool) => tool.name)
 
     expect(toolNames).toContain('transloadit_lint_assembly_instructions')
+    expect(toolNames).toContain('transloadit_search_docs')
+    expect(toolNames).toContain('transloadit_get_doc')
 
     const result = await client.callTool({
       name: 'transloadit_lint_assembly_instructions',

--- a/packages/mcp-server/test/unit/docs.test.ts
+++ b/packages/mcp-server/test/unit/docs.test.ts
@@ -25,6 +25,10 @@ describe('MCP documentation retrieval', () => {
 
     const results = await searchTransloaditDocs('resize image', 'robots', 5)
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://transloadit.com/docs/robots/llms.txt',
+      expect.anything(),
+    )
     expect(results).toEqual([
       {
         title: 'Resize images',
@@ -34,17 +38,43 @@ describe('MCP documentation retrieval', () => {
     ])
   })
 
-  it('normalizes an HTML docs URL and returns bounded Markdown', async () => {
+  it('falls back to the root index while scoped indexes are unavailable', async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(new Response('# Image resize\n\nDetailed documentation.', { status: 200 }))
+      .mockResolvedValueOnce(new Response('', { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          '- [Authentication](https://transloadit.com/docs/api/authentication.md): Sign API requests.',
+          { status: 200 },
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const results = await searchTransloaditDocs('authentication', 'api', 5)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://transloadit.com/llms.txt',
+      expect.anything(),
+    )
+    expect(results).toHaveLength(1)
+  })
+
+  it('normalizes an HTML docs URL and returns bounded Markdown', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('# Image resize\n\nDetailed documentation.', {
+        status: 200,
+      }),
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     const page = await getTransloaditDoc('https://transloadit.com/docs/robots/image-resize/', 20)
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://transloadit.com/docs/robots/image-resize.md',
-      expect.objectContaining({ headers: { Accept: 'text/markdown, text/plain;q=0.9' } }),
+      expect.objectContaining({
+        headers: { Accept: 'text/markdown, text/plain;q=0.9' },
+      }),
     )
     expect(page).toEqual({
       title: 'Image resize',
@@ -52,6 +82,36 @@ describe('MCP documentation retrieval', () => {
       markdown: '# Image resize\n\nDeta',
       truncated: true,
     })
+  })
+
+  it('streams and truncates oversized Markdown without buffering the full response', async () => {
+    const response = new Response(`# Large page\n\n${'x'.repeat(2_000)}`, {
+      headers: { 'Content-Type': 'text/markdown' },
+      status: 200,
+    })
+    const text = vi.spyOn(response, 'text')
+    const fetchMock = vi.fn().mockResolvedValue(response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const page = await getTransloaditDoc('/docs/large-page/', 1_000)
+
+    expect(page?.markdown).toHaveLength(1_000)
+    expect(page?.truncated).toBe(true)
+    expect(text).not.toHaveBeenCalled()
+  })
+
+  it('rejects a successful HTML response instead of returning it as Markdown', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('<!doctype html><title>Error</title>', {
+        headers: { 'Content-Type': 'text/html' },
+        status: 200,
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getTransloaditDoc('/docs/error/', 1_000)).rejects.toThrow(
+      'unsupported content type',
+    )
   })
 
   it('rejects non-Transloadit and non-documentation URLs without fetching', async () => {

--- a/packages/mcp-server/test/unit/docs.test.ts
+++ b/packages/mcp-server/test/unit/docs.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getTransloaditDoc, searchTransloaditDocs } from '../../src/docs.ts'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('MCP documentation retrieval', () => {
+  it('searches and scopes the public documentation index', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          [
+            '# Transloadit',
+            '- [Resize images](https://transloadit.com/docs/robots/image-resize.md): Resize and crop images.',
+            '- [Authentication](https://transloadit.com/docs/api/authentication.md): Sign API requests.',
+            '- [External](https://example.com/docs/image.md): Must not be returned.',
+          ].join('\n'),
+          { status: 200 },
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const results = await searchTransloaditDocs('resize image', 'robots', 5)
+
+    expect(results).toEqual([
+      {
+        title: 'Resize images',
+        url: 'https://transloadit.com/docs/robots/image-resize.md',
+        description: 'Resize and crop images.',
+      },
+    ])
+  })
+
+  it('normalizes an HTML docs URL and returns bounded Markdown', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('# Image resize\n\nDetailed documentation.', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const page = await getTransloaditDoc('https://transloadit.com/docs/robots/image-resize/', 20)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://transloadit.com/docs/robots/image-resize.md',
+      expect.objectContaining({ headers: { Accept: 'text/markdown, text/plain;q=0.9' } }),
+    )
+    expect(page).toEqual({
+      title: 'Image resize',
+      url: 'https://transloadit.com/docs/robots/image-resize.md',
+      markdown: '# Image resize\n\nDeta',
+      truncated: true,
+    })
+  })
+
+  it('rejects non-Transloadit and non-documentation URLs without fetching', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(await getTransloaditDoc('https://example.com/docs/secrets/', 1000)).toBeUndefined()
+    expect(await getTransloaditDoc('https://transloadit.com/pricing/', 1000)).toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- add credential-free `transloadit_search_docs` and `transloadit_get_doc` tools
- search the public llms.txt index, with optional API/Robot/SDK/FAQ scope and bounded results
- normalize public docs URLs to Markdown and cap returned page content
- reject external/non-doc URLs and sanitize upstream failures
- document the tools and add a release changeset

The search tool works with the existing top-level index. It also pairs naturally with transloadit/content#5711, which adds smaller scoped discovery indexes.

## Verification

- `corepack yarn workspace @transloadit/mcp-server check`
- 4 unit suites / 6 tests passed
- `git diff --check`