### PR TITLE
Add signed responsive image candidates

### DIFF
--- a/.changeset/bright-images-arrive.md
+++ b/.changeset/bright-images-arrive.md
@@ -1,0 +1,5 @@
+---
+'@transloadit/utils': minor
+---
+
+Add deterministic signed responsive-image candidates for Smart CDN.

--- a/knip.ts
+++ b/knip.ts
@@ -93,9 +93,13 @@ const config: KnipConfig = {
       ignore: ['dist/**', 'node_modules/**'],
     },
     'packages/utils': {
-      entry: ['src/**/*.{ts,tsx,js,jsx}'],
-      project: ['src/**/*.{ts,tsx,js,jsx}'],
+      entry: ['src/**/*.ts', 'test/**/*.ts'],
+      project: ['{src,test}/**/*.ts'],
       ignore: ['dist/**', 'node_modules/**'],
+      ignoreDependencies: [
+        // Tooling lives at the repo root in this monorepo.
+        'vitest',
+      ],
     },
     'packages/zod': {
       entry: ['src/**/*.{ts,tsx,js,jsx}', 'scripts/**/*.ts', 'test/**/*.ts'],

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "knip": "yarn run --binaries-only knip --exclude binaries --no-config-hints --no-progress",
     "pack": "node scripts/pack-transloadit.ts",
     "parity:transloadit": "node scripts/prepare-transloadit.ts && node scripts/fingerprint-pack.ts packages/transloadit --ignore-scripts --quiet --out /tmp/transloadit-after.json && node scripts/verify-fingerprint.ts --current /tmp/transloadit-after.json --diff",
-    "test:unit": "yarn workspace @transloadit/node test:unit && yarn workspace @transloadit/mcp-server test:unit && yarn workspace @transloadit/types test:unit && yarn workspace @transloadit/zod test:unit && yarn workspace @transloadit/notify-url-relay test:unit",
+    "test:unit": "yarn workspace @transloadit/utils test:unit && yarn workspace @transloadit/node test:unit && yarn workspace @transloadit/mcp-server test:unit && yarn workspace @transloadit/types test:unit && yarn workspace @transloadit/zod test:unit && yarn workspace @transloadit/notify-url-relay test:unit",
     "test:types": "yarn workspace @transloadit/zod test:types",
     "test:e2e": "yarn workspace @transloadit/node test:e2e",
     "test": "yarn workspace @transloadit/node test",
     "tsc:node": "yarn tsc:utils && node ./node_modules/typescript/bin/tsc -b packages/node/tsconfig.build.json && chmod +x packages/node/dist/cli.js",
     "tsc:types": "yarn workspace @transloadit/types generate && node ./node_modules/typescript/bin/tsc -b packages/types/tsconfig.build.json",
-    "tsc:utils": "node ./node_modules/typescript/bin/tsc -b packages/utils/tsconfig.build.json",
+    "tsc:utils": "yarn workspace @transloadit/utils lint:ts",
     "tsc:zod": "yarn workspace @transloadit/zod sync && node ./node_modules/typescript/bin/tsc -b packages/zod/tsconfig.build.json"
   },
   "devDependencies": {

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -24,7 +24,11 @@ const verified = await verifyWebhookSignature({
 ## Node usage
 
 ```ts
-import { signParamsSync, getSignedSmartCdnUrl } from '@transloadit/utils/node'
+import {
+  getSignedSmartCdnImageCandidates,
+  getSignedSmartCdnUrl,
+  signParamsSync,
+} from '@transloadit/utils/node'
 
 const signature = signParamsSync(paramsString, authSecret)
 const url = getSignedSmartCdnUrl({
@@ -34,6 +38,15 @@ const url = getSignedSmartCdnUrl({
   authKey,
   authSecret,
 })
+const imageCandidates = getSignedSmartCdnImageCandidates({
+  authKey,
+  authSecret,
+  // Reuse one absolute expiry across a build instead of recomputing it per request.
+  expiresAt,
+  input: 'https://example.com/image.jpg',
+  widths: [320, 640, 960],
+  workspace,
+})
 ```
 
 ## API
@@ -42,3 +55,5 @@ const url = getSignedSmartCdnUrl({
 - `verifyWebhookSignature({ rawBody, signatureHeader, authSecret })`: validates webhook signatures.
 - `signParamsSync(paramsString, authSecret, algorithm?)`: Node-only sync signature helper.
 - `getSignedSmartCdnUrl(options)`: Node-only Smart CDN URL signer.
+- `getSignedSmartCdnImageCandidates(options)`: deterministic signed AVIF and WebP `srcset`
+  candidates plus the original fallback URL.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,9 +27,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "lint:ts": "../../node_modules/.bin/tsc --build tsconfig.build.json",
+    "lint:ts": "../../node_modules/.bin/tsc --build tsconfig.build.json && ../../node_modules/.bin/tsc --noEmit --project tsconfig.json",
     "build": "../../node_modules/.bin/tsc --build tsconfig.build.json",
-    "check": "yarn lint:ts",
+    "check": "yarn lint:ts && yarn test:unit",
+    "test:unit": "../../node_modules/.bin/vitest run ./test",
     "prepack": "yarn build"
   },
   "devDependencies": {

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -6,6 +6,33 @@ export type { SignatureAlgorithm } from './index.ts'
 
 export type SignatureAlgorithmInput = SignatureAlgorithm | (string & {})
 
+type SmartCdnImageFormat = 'avif' | 'png' | 'webp'
+
+interface SmartCdnImageCandidates {
+  fallback: string
+  sources: Partial<Record<SmartCdnImageFormat, string>>
+}
+
+/** Options for deterministic, server-generated Smart CDN image candidates. */
+export interface SmartCdnImageCandidatesOptions {
+  /** Transloadit auth key used to sign every candidate URL. */
+  authKey: string
+  /** Transloadit auth secret used to sign every candidate URL. */
+  authSecret: string
+  /** One absolute expiry in milliseconds since UNIX epoch, shared by every candidate. */
+  expiresAt: number
+  /** Formats and their quality values. Defaults to AVIF 45 and WebP 75. */
+  formats?: Readonly<Partial<Record<SmartCdnImageFormat, number>>>
+  /** Absolute HTTP(S) source URL accepted by the responsive-image Template. */
+  input: string
+  /** Compatible Template override. Defaults to `builtin/serve-image@0.0.1`. */
+  template?: string
+  /** Up to 32 intrinsic widths. Each value must be an integer from 1 through 8000. */
+  widths: readonly number[]
+  /** Workspace slug. */
+  workspace: string
+}
+
 export type SmartCdnUrlOptions = {
   /**
    * Workspace slug.
@@ -36,6 +63,70 @@ export type SmartCdnUrlOptions = {
    * Transloadit auth secret used to sign the URL.
    */
   authSecret: string
+}
+
+const defaultSmartCdnImageFormats: Readonly<Partial<Record<SmartCdnImageFormat, number>>> = {
+  avif: 45,
+  webp: 75,
+}
+const defaultSmartCdnImageTemplate = 'builtin/serve-image@0.0.1'
+const smartCdnImageFormats: readonly SmartCdnImageFormat[] = ['avif', 'webp', 'png']
+const smartCdnImageMaxDimension = 8000
+const smartCdnImageMaxWidths = 32
+
+function isSmartCdnImageFormat(value: string): value is SmartCdnImageFormat {
+  return value === 'avif' || value === 'png' || value === 'webp'
+}
+
+function validateSmartCdnImageDimension(width: number): void {
+  if (!Number.isInteger(width) || width < 1 || width > smartCdnImageMaxDimension) {
+    throw new RangeError(`width must be an integer from 1 through ${smartCdnImageMaxDimension}`)
+  }
+}
+
+function validateSmartCdnImageQuality(quality: number): void {
+  if (!Number.isInteger(quality) || quality < 1 || quality > 100) {
+    throw new RangeError('quality must be an integer from 1 through 100')
+  }
+}
+
+function validateSmartCdnImageInput(input: string): void {
+  if (typeof input !== 'string' || input.trim() !== input || input.includes('|')) {
+    throw new TypeError('input must be a single HTTP or HTTPS URL string')
+  }
+  if (!URL.canParse(input)) {
+    throw new TypeError('input must be an HTTP or HTTPS URL')
+  }
+
+  const protocol = new URL(input).protocol
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new TypeError('input must be an HTTP or HTTPS URL')
+  }
+}
+
+function validateSmartCdnImageFormats(
+  formats: Readonly<Partial<Record<SmartCdnImageFormat, number>>>,
+): void {
+  for (const format of Object.keys(formats)) {
+    if (!isSmartCdnImageFormat(format)) {
+      throw new TypeError(`Unsupported Smart CDN image format: ${format}`)
+    }
+  }
+
+  let formatCount = 0
+  for (const format of smartCdnImageFormats) {
+    const quality = formats[format]
+    if (quality == null) {
+      continue
+    }
+
+    validateSmartCdnImageQuality(quality)
+    formatCount += 1
+  }
+
+  if (formatCount === 0) {
+    throw new TypeError('formats must contain at least one value')
+  }
 }
 
 export const signParamsSync = (
@@ -79,4 +170,68 @@ export const getSignedSmartCdnUrl = (opts: SmartCdnUrlOptions): string => {
 
   queryParams.set('sig', `sha256:${signature}`)
   return `https://${workspaceSlug}.tlcdn.com/${templateSlug}/${inputField}?${queryParams}`
+}
+
+/**
+ * Builds deterministic signed Smart CDN candidates for server-rendered `<picture>` elements.
+ *
+ * Width descriptors are only accurate when callers do not request widths above the source image's
+ * intrinsic width. The helper deliberately keeps the Built-in in width-only `fit` mode.
+ */
+export function getSignedSmartCdnImageCandidates(
+  opts: SmartCdnImageCandidatesOptions,
+): SmartCdnImageCandidates {
+  if (typeof opts.authKey !== 'string' || opts.authKey === '') {
+    throw new TypeError('authKey is required')
+  }
+  if (typeof opts.authSecret !== 'string' || opts.authSecret === '') {
+    throw new TypeError('authSecret is required')
+  }
+  if (!Number.isSafeInteger(opts.expiresAt) || opts.expiresAt <= 0) {
+    throw new RangeError('expiresAt must be a positive safe integer')
+  }
+  if (!Array.isArray(opts.widths) || opts.widths.length === 0) {
+    throw new TypeError('widths must contain at least one value')
+  }
+  if (opts.widths.length > smartCdnImageMaxWidths) {
+    throw new RangeError(`widths must contain at most ${smartCdnImageMaxWidths} values`)
+  }
+
+  validateSmartCdnImageInput(opts.input)
+  const widths = [...new Set(opts.widths)]
+  if (widths.length > smartCdnImageMaxWidths) {
+    throw new RangeError(`widths must contain at most ${smartCdnImageMaxWidths} unique values`)
+  }
+  for (const width of widths) {
+    validateSmartCdnImageDimension(width)
+  }
+
+  const formats = opts.formats ?? defaultSmartCdnImageFormats
+  validateSmartCdnImageFormats(formats)
+
+  widths.sort((left, right) => left - right)
+  const sources: Partial<Record<SmartCdnImageFormat, string>> = {}
+  for (const format of smartCdnImageFormats) {
+    const quality = formats[format]
+    if (quality == null) {
+      continue
+    }
+
+    const candidates: string[] = []
+    for (const width of widths) {
+      const url = getSignedSmartCdnUrl({
+        authKey: opts.authKey,
+        authSecret: opts.authSecret,
+        expiresAt: opts.expiresAt,
+        input: opts.input,
+        template: opts.template ?? defaultSmartCdnImageTemplate,
+        urlParams: { f: format, q: quality, r: 'fit', w: width },
+        workspace: opts.workspace,
+      })
+      candidates.push(`${url} ${width}w`)
+    }
+    sources[format] = candidates.join(', ')
+  }
+
+  return { fallback: opts.input, sources }
 }

--- a/packages/utils/test/node.test.ts
+++ b/packages/utils/test/node.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getSignedSmartCdnImageCandidates } from '../src/node.ts'
+
+const baseOptions = {
+  authKey: 'test-key',
+  authSecret: 'test-secret',
+  expiresAt: 1_900_000_000_000,
+  input: 'https://assets.example/image.jpg?version=1',
+  widths: [640, 320, 640],
+  workspace: 'test-workspace',
+}
+
+interface ParsedCandidate {
+  url: URL
+  width: number
+}
+
+function requireSource(source: string | undefined): string {
+  if (source == null) {
+    throw new Error('Expected image source candidates')
+  }
+  return source
+}
+
+function parseSrcSet(srcSet: string): ParsedCandidate[] {
+  return srcSet.split(', ').map((candidate) => {
+    const separator = candidate.lastIndexOf(' ')
+    const descriptor = candidate.slice(separator + 1)
+    if (separator === -1 || !descriptor.endsWith('w')) {
+      throw new Error(`Invalid srcset candidate: ${candidate}`)
+    }
+
+    return {
+      url: new URL(candidate.slice(0, separator)),
+      width: Number(descriptor.slice(0, -1)),
+    }
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('getSignedSmartCdnImageCandidates', () => {
+  it('builds deterministic AVIF and WebP srcsets with measured quality defaults', () => {
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      throw new Error('The candidate builder must not read the clock')
+    })
+
+    const result = getSignedSmartCdnImageCandidates(baseOptions)
+
+    expect(result).toEqual(getSignedSmartCdnImageCandidates(baseOptions))
+    expect(result.fallback).toBe(baseOptions.input)
+    expect(Object.keys(result.sources)).toEqual(['avif', 'webp'])
+
+    const avifCandidates = parseSrcSet(requireSource(result.sources.avif))
+    const webpCandidates = parseSrcSet(requireSource(result.sources.webp))
+
+    expect(avifCandidates.map(({ width }) => width)).toEqual([320, 640])
+    expect(webpCandidates.map(({ width }) => width)).toEqual([320, 640])
+
+    for (const { url, width } of avifCandidates) {
+      expect(url.pathname).toBe(
+        '/builtin%2Fserve-image%400.0.1/' +
+          'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1',
+      )
+      expect(url.searchParams.get('auth_key')).toBe(baseOptions.authKey)
+      expect(url.searchParams.get('exp')).toBe(`${baseOptions.expiresAt}`)
+      expect(url.searchParams.get('f')).toBe('avif')
+      expect(url.searchParams.get('q')).toBe('45')
+      expect(url.searchParams.get('r')).toBe('fit')
+      expect(url.searchParams.get('w')).toBe(`${width}`)
+      expect(url.searchParams.get('sig')).toMatch(/^sha256:[a-f0-9]{64}$/)
+    }
+
+    for (const { url, width } of webpCandidates) {
+      expect(url.searchParams.get('f')).toBe('webp')
+      expect(url.searchParams.get('q')).toBe('75')
+      expect(url.searchParams.get('w')).toBe(`${width}`)
+    }
+  })
+
+  it('supports a compatible Template override and explicit formats', () => {
+    const result = getSignedSmartCdnImageCandidates({
+      ...baseOptions,
+      formats: { png: 90, webp: 82 },
+      template: 'customer-image',
+      widths: [480],
+    })
+
+    expect(result.sources.avif).toBeUndefined()
+    expect(Object.keys(result.sources)).toEqual(['webp', 'png'])
+
+    const [webpCandidate] = parseSrcSet(requireSource(result.sources.webp))
+    const [pngCandidate] = parseSrcSet(requireSource(result.sources.png))
+
+    expect(webpCandidate?.url.pathname).toBe(
+      '/customer-image/https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1',
+    )
+    expect(webpCandidate?.url.searchParams.get('q')).toBe('82')
+    expect(pngCandidate?.url.searchParams.get('q')).toBe('90')
+  })
+
+  it('rejects values that the Built-in cannot execute safely', () => {
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, widths: [] })).toThrow(
+      'widths must contain at least one value',
+    )
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, widths: [0] })).toThrow(
+      'width must be an integer from 1 through 8000',
+    )
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, widths: [8001] })).toThrow(
+      'width must be an integer from 1 through 8000',
+    )
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, widths: [1.5] })).toThrow(
+      'width must be an integer from 1 through 8000',
+    )
+    expect(() =>
+      getSignedSmartCdnImageCandidates({ ...baseOptions, formats: { avif: 0 } }),
+    ).toThrow('quality must be an integer from 1 through 100')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({ ...baseOptions, formats: { webp: 101 } }),
+    ).toThrow('quality must be an integer from 1 through 100')
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, formats: {} })).toThrow(
+      'formats must contain at least one value',
+    )
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        // @ts-expect-error The runtime boundary must reject unsupported JavaScript input.
+        formats: { jpeg: 75 },
+      }),
+    ).toThrow('Unsupported Smart CDN image format: jpeg')
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, expiresAt: 0 })).toThrow(
+      'expiresAt must be a positive safe integer',
+    )
+    expect(() =>
+      getSignedSmartCdnImageCandidates({ ...baseOptions, expiresAt: Number.MAX_VALUE }),
+    ).toThrow('expiresAt must be a positive safe integer')
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, input: 'not-a-url' })).toThrow(
+      'input must be an HTTP or HTTPS URL',
+    )
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        // @ts-expect-error The runtime boundary must not coerce URL objects.
+        input: new URL('https://assets.example/image.jpg'),
+      }),
+    ).toThrow('input must be a single HTTP or HTTPS URL string')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        input: ' https://assets.example/image.jpg',
+      }),
+    ).toThrow('input must be a single HTTP or HTTPS URL string')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        input: 'https://assets.example/one.jpg|https://assets.example/two.jpg',
+      }),
+    ).toThrow('input must be a single HTTP or HTTPS URL string')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({ ...baseOptions, input: 'ftp://assets.example/image.jpg' }),
+    ).toThrow('input must be an HTTP or HTTPS URL')
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, authKey: '' })).toThrow(
+      'authKey is required',
+    )
+    expect(() => getSignedSmartCdnImageCandidates({ ...baseOptions, authSecret: '' })).toThrow(
+      'authSecret is required',
+    )
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        // @ts-expect-error The runtime boundary must reject unsupported JavaScript input.
+        authKey: null,
+      }),
+    ).toThrow('authKey is required')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        // @ts-expect-error The runtime boundary must reject unsupported JavaScript input.
+        widths: undefined,
+      }),
+    ).toThrow('widths must contain at least one value')
+    expect(() =>
+      getSignedSmartCdnImageCandidates({
+        ...baseOptions,
+        widths: Array.from({ length: 33 }, (_, index) => index + 1),
+      }),
+    ).toThrow('widths must contain at most 32 values')
+  })
+})

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "files": [],
+  "exclude": ["coverage", "dist", "src"],
   "references": [{ "path": "./tsconfig.build.json" }],
   "compilerOptions": {
     "checkJs": true,
@@ -10,6 +10,7 @@
     "noImplicitOverride": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "types": ["node", "vitest/globals"]
   }
 }


### PR DESCRIPTION
## Why

Smart CDN now has a deployed, bounded `builtin/serve-image@0.0.1`, but applications still have to hand-roll and separately sign every responsive-image candidate. A small framework-neutral helper lets server renderers produce deterministic `<picture>` sources without exposing credentials or coupling the contract to React or Next.js.

## What

- add one Node-only `getSignedSmartCdnImageCandidates` helper to `@transloadit/utils`
- generate sorted, deduplicated, signed AVIF/WebP srcsets with format-specific quality defaults
- require one caller-selected expiry shared across all candidates for stable cache keys
- pin the safe Built-in by default while allowing a compatible Template override
- preserve the original HTTP(S) source as the browser fallback
- cap dimensions and candidate count before signing
- add the utils tests to the monorepo check and prepare a minor Changeset

## Verification

- red/green unit coverage for deterministic URLs, format qualities, Template override, validation, and candidate-count bounds
- `yarn check`
- `yarn verify:full`
- `yarn release:pack:dry-run`
- council review with two P2 findings; both fixed with failing regressions before implementation

## Next

Consume the published minor from Content in a separate, signed below-the-fold dogfood PR. Compare repeated Lighthouse, byte, cold-miss, and warm-hit results against both main and the native Next.js optimizer before touching LCP images.