### PR TITLE
Structure Smart CDN image candidates

### DIFF
--- a/.changeset/tidy-image-candidates.md
+++ b/.changeset/tidy-image-candidates.md
@@ -1,0 +1,6 @@
+---
+'@transloadit/utils': patch
+---
+
+Replace the two-day-old Smart CDN candidate return value with structured sources for
+renderer-independent integrations. The only application consumer migrates with this release.

--- a/docs/prompts/2026-08-25-structured-smartcdn-image-candidates.md
+++ b/docs/prompts/2026-08-25-structured-smartcdn-image-candidates.md
@@ -1,0 +1,33 @@
+# Structured Smart CDN image candidates
+
+## Why
+
+`getSignedSmartCdnImageCandidates()` was introduced on 2026-08-24 with renderer-specific `srcset`
+strings. Content and its generated Website mirror are its only application consumers. Replace that
+young contract before broader adoption so the signing helper returns ordered, serializable data and
+renderers retain ownership of HTML serialization.
+
+## Pull request checklist
+
+- [x] Inspect the complete context for [node-sdk #475](https://github.com/transloadit/node-sdk/pull/475).
+- [x] Confirm there are no open review threads or human review comments.
+- [x] Return exported structured sources with format, quality, URL, and width data.
+- [x] Remove the renderer-specific return shape without compatibility scaffolding.
+- [x] Add a patch changeset that explicitly documents the intentional replacement.
+- [x] Run `corepack yarn workspace @transloadit/utils check`.
+- [x] Run `corepack yarn check`.
+- [x] Run `corepack yarn verify:full`.
+- [x] Run `corepack yarn release:pack:dry-run`.
+- [x] Run council review. Its sole finding requested major-version treatment; this was deliberately
+      rejected under the verified zero-external-consumer exception for APIs introduced in the last
+      two days.
+- [ ] Confirm every GitHub check passes.
+- [ ] Squash-merge node-sdk #475.
+- [ ] Land the generated Version Packages PR and verify the patch on npm.
+- [ ] Migrate Content to the exact released version and complete its browser/network validation.
+
+## Contract
+
+The utility owns deterministic signing and returns structured candidates. Content and the eventual
+`@transloadit/img` renderer turn those candidates into `srcset` strings. Geometry and crop policy
+remain unchanged until a real caller proves the next capability.

--- a/docs/prompts/2026-08-25-structured-smartcdn-image-candidates.md
+++ b/docs/prompts/2026-08-25-structured-smartcdn-image-candidates.md
@@ -21,10 +21,12 @@ renderers retain ownership of HTML serialization.
 - [x] Run council review. Its sole finding requested major-version treatment; this was deliberately
       rejected under the verified zero-external-consumer exception for APIs introduced in the last
       two days.
-- [ ] Confirm every GitHub check passes.
-- [ ] Squash-merge node-sdk #475.
-- [ ] Land the generated Version Packages PR and verify the patch on npm.
-- [ ] Migrate Content to the exact released version and complete its browser/network validation.
+- [x] Confirm every GitHub check passes.
+
+## Next actions
+
+Squash-merge node-sdk #475, land the generated Version Packages PR, verify the patch on npm, and
+then migrate Content to that exact release with browser and network validation.
 
 ## Contract
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -47,6 +47,10 @@ const imageCandidates = getSignedSmartCdnImageCandidates({
   widths: [320, 640, 960],
   workspace,
 })
+
+for (const source of imageCandidates.sources) {
+  console.log(source.format, source.quality, source.candidates)
+}
 ```
 
 ## API
@@ -55,5 +59,5 @@ const imageCandidates = getSignedSmartCdnImageCandidates({
 - `verifyWebhookSignature({ rawBody, signatureHeader, authSecret })`: validates webhook signatures.
 - `signParamsSync(paramsString, authSecret, algorithm?)`: Node-only sync signature helper.
 - `getSignedSmartCdnUrl(options)`: Node-only Smart CDN URL signer.
-- `getSignedSmartCdnImageCandidates(options)`: deterministic signed AVIF and WebP `srcset`
+- `getSignedSmartCdnImageCandidates(options)`: deterministic structured, signed AVIF and WebP
   candidates plus the original fallback URL.

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -6,11 +6,26 @@ export type { SignatureAlgorithm } from './index.ts'
 
 export type SignatureAlgorithmInput = SignatureAlgorithm | (string & {})
 
-type SmartCdnImageFormat = 'avif' | 'png' | 'webp'
+/** Image formats supported by the responsive-image Built-in. */
+export type SmartCdnImageFormat = 'avif' | 'png' | 'webp'
 
-interface SmartCdnImageCandidates {
-  fallback: string
-  sources: Partial<Record<SmartCdnImageFormat, string>>
+/** One signed Smart CDN rendition at a specific intrinsic width. */
+export interface SmartCdnImageCandidate {
+  url: string
+  width: number
+}
+
+/** Ordered candidates for one image format and quality. */
+export interface SmartCdnImageSource {
+  candidates: readonly SmartCdnImageCandidate[]
+  format: SmartCdnImageFormat
+  quality: number
+}
+
+/** Structured data for rendering a responsive image. */
+export interface SmartCdnImageCandidates {
+  fallbackUrl: string
+  sources: readonly SmartCdnImageSource[]
 }
 
 /** Options for deterministic, server-generated Smart CDN image candidates. */
@@ -210,14 +225,14 @@ export function getSignedSmartCdnImageCandidates(
   validateSmartCdnImageFormats(formats)
 
   widths.sort((left, right) => left - right)
-  const sources: Partial<Record<SmartCdnImageFormat, string>> = {}
+  const sources: SmartCdnImageSource[] = []
   for (const format of smartCdnImageFormats) {
     const quality = formats[format]
     if (quality == null) {
       continue
     }
 
-    const candidates: string[] = []
+    const candidates: SmartCdnImageCandidate[] = []
     for (const width of widths) {
       const url = getSignedSmartCdnUrl({
         authKey: opts.authKey,
@@ -228,10 +243,10 @@ export function getSignedSmartCdnImageCandidates(
         urlParams: { f: format, q: quality, r: 'fit', w: width },
         workspace: opts.workspace,
       })
-      candidates.push(`${url} ${width}w`)
+      candidates.push({ url, width })
     }
-    sources[format] = candidates.join(', ')
+    sources.push({ candidates, format, quality })
   }
 
-  return { fallback: opts.input, sources }
+  return { fallbackUrl: opts.input, sources }
 }

--- a/packages/utils/test/node.test.ts
+++ b/packages/utils/test/node.test.ts
@@ -11,31 +11,25 @@ const baseOptions = {
   workspace: 'test-workspace',
 }
 
-interface ParsedCandidate {
-  url: URL
-  width: number
-}
-
-function requireSource(source: string | undefined): string {
-  if (source == null) {
+function requireSource(
+  sources: ReturnType<typeof getSignedSmartCdnImageCandidates>['sources'],
+  format: 'avif' | 'png' | 'webp',
+): (typeof sources)[number] {
+  const source = sources.find((candidateSource) => candidateSource.format === format)
+  if (source === undefined) {
     throw new Error('Expected image source candidates')
   }
   return source
 }
 
-function parseSrcSet(srcSet: string): ParsedCandidate[] {
-  return srcSet.split(', ').map((candidate) => {
-    const separator = candidate.lastIndexOf(' ')
-    const descriptor = candidate.slice(separator + 1)
-    if (separator === -1 || !descriptor.endsWith('w')) {
-      throw new Error(`Invalid srcset candidate: ${candidate}`)
-    }
-
-    return {
-      url: new URL(candidate.slice(0, separator)),
-      width: Number(descriptor.slice(0, -1)),
-    }
-  })
+function requireFirstCandidate(
+  source: ReturnType<typeof requireSource>,
+): (typeof source.candidates)[number] {
+  const candidate = source.candidates[0]
+  if (candidate === undefined) {
+    throw new Error('Expected at least one image candidate')
+  }
+  return candidate
 }
 
 afterEach(() => {
@@ -43,7 +37,7 @@ afterEach(() => {
 })
 
 describe('getSignedSmartCdnImageCandidates', () => {
-  it('builds deterministic AVIF and WebP srcsets with measured quality defaults', () => {
+  it('builds deterministic structured AVIF and WebP candidates with measured defaults', () => {
     vi.spyOn(Date, 'now').mockImplementation(() => {
       throw new Error('The candidate builder must not read the clock')
     })
@@ -51,16 +45,19 @@ describe('getSignedSmartCdnImageCandidates', () => {
     const result = getSignedSmartCdnImageCandidates(baseOptions)
 
     expect(result).toEqual(getSignedSmartCdnImageCandidates(baseOptions))
-    expect(result.fallback).toBe(baseOptions.input)
-    expect(Object.keys(result.sources)).toEqual(['avif', 'webp'])
+    expect(result.fallbackUrl).toBe(baseOptions.input)
+    expect(result.sources.map(({ format }) => format)).toEqual(['avif', 'webp'])
 
-    const avifCandidates = parseSrcSet(requireSource(result.sources.avif))
-    const webpCandidates = parseSrcSet(requireSource(result.sources.webp))
+    const avifSource = requireSource(result.sources, 'avif')
+    const webpSource = requireSource(result.sources, 'webp')
 
-    expect(avifCandidates.map(({ width }) => width)).toEqual([320, 640])
-    expect(webpCandidates.map(({ width }) => width)).toEqual([320, 640])
+    expect(avifSource.quality).toBe(45)
+    expect(webpSource.quality).toBe(75)
+    expect(avifSource.candidates.map(({ width }) => width)).toEqual([320, 640])
+    expect(webpSource.candidates.map(({ width }) => width)).toEqual([320, 640])
 
-    for (const { url, width } of avifCandidates) {
+    for (const { url: rawUrl, width } of avifSource.candidates) {
+      const url = new URL(rawUrl)
       expect(url.pathname).toBe(
         '/builtin%2Fserve-image%400.0.1/' +
           'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1',
@@ -74,7 +71,8 @@ describe('getSignedSmartCdnImageCandidates', () => {
       expect(url.searchParams.get('sig')).toMatch(/^sha256:[a-f0-9]{64}$/)
     }
 
-    for (const { url, width } of webpCandidates) {
+    for (const { url: rawUrl, width } of webpSource.candidates) {
+      const url = new URL(rawUrl)
       expect(url.searchParams.get('f')).toBe('webp')
       expect(url.searchParams.get('q')).toBe('75')
       expect(url.searchParams.get('w')).toBe(`${width}`)
@@ -89,17 +87,16 @@ describe('getSignedSmartCdnImageCandidates', () => {
       widths: [480],
     })
 
-    expect(result.sources.avif).toBeUndefined()
-    expect(Object.keys(result.sources)).toEqual(['webp', 'png'])
+    expect(result.sources.map(({ format }) => format)).toEqual(['webp', 'png'])
 
-    const [webpCandidate] = parseSrcSet(requireSource(result.sources.webp))
-    const [pngCandidate] = parseSrcSet(requireSource(result.sources.png))
+    const webpCandidate = requireFirstCandidate(requireSource(result.sources, 'webp'))
+    const pngCandidate = requireFirstCandidate(requireSource(result.sources, 'png'))
 
-    expect(webpCandidate?.url.pathname).toBe(
+    expect(new URL(webpCandidate.url).pathname).toBe(
       '/customer-image/https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1',
     )
-    expect(webpCandidate?.url.searchParams.get('q')).toBe('82')
-    expect(pngCandidate?.url.searchParams.get('q')).toBe('90')
+    expect(new URL(webpCandidate.url).searchParams.get('q')).toBe('82')
+    expect(new URL(pngCandidate.url).searchParams.get('q')).toBe('90')
   })
 
   it('rejects values that the Built-in cannot execute safely', () => {


### PR DESCRIPTION
## Why

The responsive-image helper currently returns preformatted `srcset` strings, coupling the signing
primitive to one renderer. Its only application consumer is still under our control, so this is the
right moment to replace that two-day-old contract with a renderer-neutral model before broader
adoption.

## What changed

- return ordered structured sources containing format, quality, URL, and width data
- export the candidate, source, format, and result types
- retain deterministic signing, format ordering, width deduplication, and validation behavior
- document the new result and ship it as an intentional patch-level replacement

## Verification

- `corepack yarn workspace @transloadit/utils check`
- `corepack yarn check`
- `corepack yarn verify:full`
- `corepack yarn release:pack:dry-run`
- council review; the sole semver finding was explicitly accepted for this newly introduced,
  zero-external-consumer API
