### PR TITLE
utils: Smart CDN URL grammar — parse, unsigned build, strip auth, trusted baseUrl

### DIFF
--- a/.changeset/smart-cdn-grammar.md
+++ b/.changeset/smart-cdn-grammar.md
@@ -1,0 +1,11 @@
+---
+"@transloadit/utils": minor
+---
+
+Add the rest of the Smart CDN URL grammar next to `getSignedSmartCdnUrl`, so applications stop
+carrying their own copies: `getSmartCdnUrl` (unsigned builder), `parseSmartCdnUrl` (the inverse of
+the builders — decodes once, keeps repeated query parameters, returns `auth_key`/`exp`/`sig` as
+`auth`) and `stripSmartCdnAuth` (removes the signature parameters byte-for-byte otherwise). Both
+builders accept a trusted `baseUrl` option (for example a local api2's URL Transform endpoint with
+a `{workspace}` placeholder); the signature does not cover the host, so it must come from
+configuration, never from user input. Exported from the root and the `./node` entry.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -14,7 +14,14 @@ Everything in the root export runs on WebCrypto, so it works in browsers (secure
 `https://` or `localhost`), edge runtimes, and Node.
 
 ```ts
-import { getSignedSmartCdnUrl, signParams, verifyWebhookSignature } from '@transloadit/utils'
+import {
+  getSignedSmartCdnUrl,
+  getSmartCdnUrl,
+  parseSmartCdnUrl,
+  signParams,
+  stripSmartCdnAuth,
+  verifyWebhookSignature,
+} from '@transloadit/utils'
 
 const signature = await signParams(paramsString, authSecret)
 const verified = await verifyWebhookSignature({
@@ -30,6 +37,29 @@ const url = await getSignedSmartCdnUrl({
   authSecret,
 })
 ```
+
+### Smart CDN URL grammar
+
+The URL builders and parser share one grammar, so a URL built here parses back into the options
+that built it (and vice versa):
+
+```ts
+// Unsigned, for workspaces that do not require signature authentication.
+const publicUrl = getSmartCdnUrl({ workspace, template, input, urlParams: { w: 640 } })
+
+// Inverse of the builders: percent-decodes once, keeps repeated params as arrays,
+// and returns `auth_key`/`exp`/`sig` separately as `auth`.
+const { workspace, template, input, urlParams, auth } = parseSmartCdnUrl(url)
+
+// Drops `auth_key`, `exp`, `sig` (and api2's `hsh`), leaving every other byte untouched.
+const unsigned = stripSmartCdnAuth(url)
+```
+
+Both builders accept a `baseUrl` that replaces `https://{workspace}.tlcdn.com`, for example a local
+api2's URL Transform endpoint `https://api2-devdock.transloadit.dev/file/{workspace}` (a literal
+`{workspace}` is substituted). The signature does not cover the host, so treat `baseUrl` as trusted
+configuration and never derive it from user input. Pass the same `baseUrl` to `parseSmartCdnUrl` to
+parse URLs built with it.
 
 ## Node usage
 
@@ -70,6 +100,11 @@ for (const source of imageCandidates.sources) {
 - `verifyWebhookSignature({ rawBody, signatureHeader, authSecret })`: validates webhook signatures.
 - `getSignedSmartCdnUrl(options)`: async, WebCrypto-based Smart CDN URL signer. Byte-identical to
   the Node variant below.
+- `getSmartCdnUrl(options)`: unsigned Smart CDN URL builder (same options minus credentials/expiry).
+- `parseSmartCdnUrl(url, { baseUrl?, workspace? })`: parses a Smart CDN URL into
+  `{ workspace, template, input, urlParams, auth?, baseUrl? }`; throws on anything else.
+- `stripSmartCdnAuth(url)`: removes the signature parameters, byte-for-byte otherwise.
+- `baseUrl` (option of both builders): trusted replacement for `https://{workspace}.tlcdn.com`.
 - `signParamsSync(paramsString, authSecret, algorithm?)`: Node-only sync signature helper.
 - `getSignedSmartCdnUrl(options)` from `@transloadit/utils/node`: synchronous Smart CDN URL signer.
 - `getSignedSmartCdnImageCandidates(options)`: deterministic structured, signed AVIF and WebP

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,9 +4,16 @@ import { finishSmartCdnUrl, prepareSmartCdnUrl } from './smartCdn.ts'
 
 export type SignatureAlgorithm = 'sha1' | 'sha256' | 'sha384' | 'sha512'
 
-export type { SmartCdnUrlOptions } from './smartCdn.ts'
+export type {
+  ParsedSmartCdnUrl,
+  ParseSmartCdnUrlOptions,
+  SmartCdnUnsignedUrlOptions,
+  SmartCdnUrlOptions,
+  SmartCdnUrlParams,
+} from './smartCdn.ts'
 
 export * from './assemblyInstructionsCompiler.ts'
+export { getSmartCdnUrl, parseSmartCdnUrl, stripSmartCdnAuth } from './smartCdn.ts'
 
 const algorithmMap = {
   sha1: 'SHA-1',

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -6,7 +6,15 @@ import { createHmac } from 'node:crypto'
 import { finishSmartCdnUrl, prepareSmartCdnUrl } from './smartCdn.ts'
 
 export type { SignatureAlgorithm } from './index.ts'
-export type { SmartCdnUrlOptions } from './smartCdn.ts'
+export type {
+  ParsedSmartCdnUrl,
+  ParseSmartCdnUrlOptions,
+  SmartCdnUnsignedUrlOptions,
+  SmartCdnUrlOptions,
+  SmartCdnUrlParams,
+} from './smartCdn.ts'
+
+export { getSmartCdnUrl, parseSmartCdnUrl, stripSmartCdnAuth } from './smartCdn.ts'
 
 export type SignatureAlgorithmInput = SignatureAlgorithm | (string & {})
 

--- a/packages/utils/src/smartCdn.ts
+++ b/packages/utils/src/smartCdn.ts
@@ -1,8 +1,20 @@
 /**
- * Smart CDN URL building shared by the synchronous Node signer (`@transloadit/utils/node`) and the
- * asynchronous WebCrypto signer (`@transloadit/utils`). Only the HMAC differs between the two, so
- * the string-to-sign and the final URL are assembled here and cannot drift apart.
+ * Smart CDN URL grammar shared by the synchronous Node signer (`@transloadit/utils/node`) and the
+ * asynchronous WebCrypto signer (`@transloadit/utils`): building (signed and unsigned), parsing,
+ * and stripping signature parameters. Only the HMAC differs between the two signers, so the
+ * string-to-sign and the final URL are assembled here and cannot drift apart.
  */
+
+const SMART_CDN_HOST_SUFFIX = '.tlcdn.com'
+const WORKSPACE_PLACEHOLDER = '{workspace}'
+/** Query parameters that carry the signature; `hsh` is an api2-side hash that is stripped too. */
+const SIGNATURE_PARAMS = new Set(['auth_key', 'exp', 'sig'])
+const STRIPPED_PARAMS = new Set([...SIGNATURE_PARAMS, 'hsh'])
+
+export type SmartCdnUrlParams = Record<
+  string,
+  boolean | number | string | (boolean | number | string)[]
+>
 
 export type SmartCdnUrlOptions = {
   /**
@@ -20,7 +32,7 @@ export type SmartCdnUrlOptions = {
   /**
    * Additional parameters for the URL query string.
    */
-  urlParams?: Record<string, boolean | number | string | (boolean | number | string)[]>
+  urlParams?: SmartCdnUrlParams
   /**
    * Expiration timestamp of the signature in milliseconds since UNIX epoch.
    * Defaults to 1 hour from now.
@@ -34,7 +46,23 @@ export type SmartCdnUrlOptions = {
    * Transloadit auth secret used to sign the URL.
    */
   authSecret: string
+  /**
+   * Base URL that replaces `https://{workspace}.tlcdn.com`, e.g. a local api2's URL Transform
+   * endpoint `https://api2-devdock.transloadit.dev/file/{workspace}`. A literal `{workspace}` is
+   * substituted with the encoded workspace slug; a trailing slash is ignored.
+   *
+   * **Trusted configuration only.** The signature does not cover the host, so a base URL taken from
+   * user input would let anyone redirect a signed URL (auth key included) to an origin of their
+   * choosing. Never derive it from request data.
+   */
+  baseUrl?: string
 }
+
+/** Options for an unsigned Smart CDN URL: the signed options without credentials or expiry. */
+export type SmartCdnUnsignedUrlOptions = Omit<
+  SmartCdnUrlOptions,
+  'authKey' | 'authSecret' | 'expiresAt'
+>
 
 /** A Smart CDN URL with everything but its signature in place. */
 export interface PreparedSmartCdnUrl {
@@ -46,22 +74,68 @@ export interface PreparedSmartCdnUrl {
     templateSlug: string
     inputField: string
     queryParams: URLSearchParams
+    /** Resolved origin + path prefix that precedes `/{template}/{input}`. */
+    baseUrl: string
   }
 }
 
-/** Validates the options and assembles the string to sign; the caller supplies the HMAC. */
-export const prepareSmartCdnUrl = (opts: SmartCdnUrlOptions): PreparedSmartCdnUrl => {
+/** The components of a Smart CDN URL, as produced by `parseSmartCdnUrl`. */
+export interface ParsedSmartCdnUrl {
+  workspace: string
+  template: string
+  input: string
+  /** Every query parameter except the signature ones; repeated parameters become arrays. */
+  urlParams: Record<string, string | string[]>
+  /** Present when the URL carries `auth_key`, `exp` and `sig`. */
+  auth?: {
+    key: string
+    /** Milliseconds since UNIX epoch. */
+    expiresAt: number
+    /** The `sig` value, e.g. `sha256:…`. */
+    signature: string
+  }
+  /** Only set when the URL was parsed against a custom `baseUrl`; feeds straight back into the builders. */
+  baseUrl?: string
+}
+
+export interface ParseSmartCdnUrlOptions {
+  /**
+   * The same trusted `baseUrl` the URL was built with (with or without `{workspace}`). Without it
+   * only `https://{workspace}.tlcdn.com/…` URLs are accepted.
+   */
+  baseUrl?: string
+  /** Workspace slug for a `baseUrl` without a `{workspace}` placeholder, where the URL cannot tell. */
+  workspace?: string
+}
+
+const validateRequired = (opts: {
+  workspace?: string
+  template?: string
+  input?: string
+}): void => {
   if (opts.workspace == null || opts.workspace === '') throw new TypeError('workspace is required')
   if (opts.template == null || opts.template === '') throw new TypeError('template is required')
   if (opts.input == null) throw new TypeError('input is required')
+}
 
-  const workspaceSlug = encodeURIComponent(opts.workspace)
-  const templateSlug = encodeURIComponent(opts.template)
-  const inputField = encodeURIComponent(opts.input)
-  const expiresAt = opts.expiresAt || Date.now() + 60 * 60 * 1000
+const resolveBaseUrl = (baseUrl: string | undefined, workspaceSlug: string): string => {
+  if (baseUrl == null) return `https://${workspaceSlug}${SMART_CDN_HOST_SUFFIX}`
+  const resolved = baseUrl.replace(/\/+$/, '').split(WORKSPACE_PLACEHOLDER).join(workspaceSlug)
+  let parsed: URL
+  try {
+    parsed = new URL(resolved)
+  } catch {
+    throw new TypeError(`baseUrl must be an absolute URL, got '${baseUrl}'`)
+  }
+  if (parsed.search !== '' || parsed.hash !== '') {
+    throw new TypeError('baseUrl must not contain a query string or fragment')
+  }
+  return resolved
+}
 
+const buildQueryParams = (urlParams: SmartCdnUrlParams | undefined): URLSearchParams => {
   const queryParams = new URLSearchParams()
-  for (const [key, value] of Object.entries(opts.urlParams || {})) {
+  for (const [key, value] of Object.entries(urlParams || {})) {
     if (Array.isArray(value)) {
       for (const val of value) {
         queryParams.append(key, `${val}`)
@@ -70,20 +144,205 @@ export const prepareSmartCdnUrl = (opts: SmartCdnUrlOptions): PreparedSmartCdnUr
       queryParams.append(key, `${value}`)
     }
   }
+  return queryParams
+}
 
+/** Validates the options and assembles the string to sign; the caller supplies the HMAC. */
+export const prepareSmartCdnUrl = (opts: SmartCdnUrlOptions): PreparedSmartCdnUrl => {
+  validateRequired(opts)
+
+  const workspaceSlug = encodeURIComponent(opts.workspace)
+  const templateSlug = encodeURIComponent(opts.template)
+  const inputField = encodeURIComponent(opts.input)
+  const expiresAt = opts.expiresAt || Date.now() + 60 * 60 * 1000
+
+  const queryParams = buildQueryParams(opts.urlParams)
   queryParams.set('auth_key', opts.authKey)
   queryParams.set('exp', `${expiresAt}`)
   queryParams.sort()
 
   return {
     stringToSign: `${workspaceSlug}/${templateSlug}/${inputField}?${queryParams}`,
-    parts: { workspaceSlug, templateSlug, inputField, queryParams },
+    parts: {
+      workspaceSlug,
+      templateSlug,
+      inputField,
+      queryParams,
+      baseUrl: resolveBaseUrl(opts.baseUrl, workspaceSlug),
+    },
   }
 }
 
 /** Appends the `sig` parameter and returns the final `https://{workspace}.tlcdn.com/…` URL. */
 export const finishSmartCdnUrl = ({ parts }: PreparedSmartCdnUrl, signatureHex: string): string => {
-  const { workspaceSlug, templateSlug, inputField, queryParams } = parts
+  const { baseUrl, templateSlug, inputField, queryParams } = parts
   queryParams.set('sig', `sha256:${signatureHex}`)
-  return `https://${workspaceSlug}.tlcdn.com/${templateSlug}/${inputField}?${queryParams}`
+  return `${baseUrl}/${templateSlug}/${inputField}?${queryParams}`
+}
+
+/**
+ * Builds an unsigned Smart CDN URL (`https://{workspace}.tlcdn.com/{template}/{input}?sortedQuery`)
+ * for workspaces that do not require signature authentication.
+ */
+export const getSmartCdnUrl = (opts: SmartCdnUnsignedUrlOptions): string => {
+  validateRequired(opts)
+  const workspaceSlug = encodeURIComponent(opts.workspace)
+  const templateSlug = encodeURIComponent(opts.template)
+  const inputField = encodeURIComponent(opts.input)
+  const queryParams = buildQueryParams(opts.urlParams)
+  queryParams.sort()
+  const query = queryParams.toString()
+  return `${resolveBaseUrl(opts.baseUrl, workspaceSlug)}/${templateSlug}/${inputField}${
+    query === '' ? '' : `?${query}`
+  }`
+}
+
+const decodeOnce = (value: string, what: string): string => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    throw new TypeError(`Not a Smart CDN URL: malformed percent-encoding in ${what}`)
+  }
+}
+
+/**
+ * Removes the signature parameters (`auth_key`, `exp`, `sig`, and api2's `hsh`) from a Smart CDN
+ * URL. Every other byte of the URL is left untouched, so the result stays comparable with URLs
+ * produced elsewhere. Idempotent.
+ */
+export const stripSmartCdnAuth = (url: string): string => {
+  const hashIndex = url.indexOf('#')
+  const fragment = hashIndex === -1 ? '' : url.slice(hashIndex)
+  const withoutFragment = hashIndex === -1 ? url : url.slice(0, hashIndex)
+  const queryIndex = withoutFragment.indexOf('?')
+  if (queryIndex === -1) return url
+  const path = withoutFragment.slice(0, queryIndex)
+  const kept = withoutFragment
+    .slice(queryIndex + 1)
+    .split('&')
+    .filter((pair) => {
+      if (pair === '') return false
+      const rawName = pair.slice(0, pair.indexOf('=') === -1 ? pair.length : pair.indexOf('='))
+      let name = rawName
+      try {
+        name = decodeURIComponent(rawName.replace(/\+/g, ' '))
+      } catch {
+        // An undecodable name is never one of ours; keep it.
+      }
+      return !STRIPPED_PARAMS.has(name)
+    })
+  return `${path}${kept.length === 0 ? '' : `?${kept.join('&')}`}${fragment}`
+}
+
+const notSmartCdnUrl = (detail: string): TypeError =>
+  new TypeError(
+    `Not a Smart CDN URL: ${detail} (expected https://{workspace}.tlcdn.com/{template}/{input}, or the configured baseUrl)`,
+  )
+
+/** Splits `origin + pathname` into the workspace slug and the `{template}/{input}` remainder. */
+const locateSmartCdnPath = (
+  parsed: URL,
+  options: ParseSmartCdnUrlOptions,
+): { workspaceSlug: string; remainder: string; baseUrl?: string } => {
+  const full = `${parsed.origin}${parsed.pathname}`
+
+  if (options.baseUrl == null) {
+    const match = /^([^.]+)\.tlcdn\.com$/i.exec(parsed.hostname)
+    if (match?.[1] == null || parsed.protocol !== 'https:') {
+      throw notSmartCdnUrl(`unexpected origin '${parsed.origin}'`)
+    }
+    return { workspaceSlug: match[1], remainder: parsed.pathname.slice(1) }
+  }
+
+  const template = options.baseUrl.replace(/\/+$/, '')
+  const placeholderIndex = template.indexOf(WORKSPACE_PLACEHOLDER)
+  if (placeholderIndex === -1) {
+    const prefix = `${template}/`
+    if (!full.startsWith(prefix))
+      throw notSmartCdnUrl(`'${full}' is not under baseUrl '${template}'`)
+    const hostMatch = /^([^.]+)\.tlcdn\.com$/i.exec(parsed.hostname)
+    const workspaceSlug =
+      options.workspace != null ? encodeURIComponent(options.workspace) : hostMatch?.[1]
+    if (workspaceSlug == null) {
+      throw notSmartCdnUrl(
+        'the workspace cannot be determined; pass `workspace` next to a baseUrl without {workspace}',
+      )
+    }
+    return { workspaceSlug, remainder: full.slice(prefix.length), baseUrl: template }
+  }
+
+  const before = template.slice(0, placeholderIndex)
+  const after = template.slice(placeholderIndex + WORKSPACE_PLACEHOLDER.length)
+  if (!full.startsWith(before)) throw notSmartCdnUrl(`'${full}' is not under baseUrl '${template}'`)
+  const rest = full.slice(before.length)
+  const slashIndex = rest.indexOf('/')
+  const workspaceSlug = slashIndex === -1 ? rest : rest.slice(0, slashIndex)
+  const afterPart = slashIndex === -1 ? '' : rest.slice(slashIndex)
+  if (workspaceSlug === '' || !afterPart.startsWith(`${after}/`)) {
+    throw notSmartCdnUrl(`'${full}' does not match baseUrl '${template}'`)
+  }
+  return {
+    workspaceSlug,
+    remainder: afterPart.slice(after.length + 1),
+    baseUrl: `${before}${workspaceSlug}${after}`,
+  }
+}
+
+/**
+ * Parses a Smart CDN URL back into the options that built it: the inverse of `getSmartCdnUrl` and
+ * `getSignedSmartCdnUrl`. Path segments are percent-decoded exactly once; query parameters are
+ * decoded by `URLSearchParams` semantics; `auth_key`/`exp`/`sig` are returned separately as `auth`.
+ */
+export const parseSmartCdnUrl = (
+  url: string,
+  options: ParseSmartCdnUrlOptions = {},
+): ParsedSmartCdnUrl => {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw notSmartCdnUrl(`'${url}' is not an absolute URL`)
+  }
+
+  const { workspaceSlug, remainder, baseUrl } = locateSmartCdnPath(parsed, options)
+  const slashIndex = remainder.indexOf('/')
+  if (slashIndex === -1) throw notSmartCdnUrl('missing the input segment')
+  const templateSlug = remainder.slice(0, slashIndex)
+  if (templateSlug === '') throw notSmartCdnUrl('missing the template segment')
+
+  const urlParams: Record<string, string | string[]> = {}
+  const signature: Record<string, string> = {}
+  for (const [key, value] of new URLSearchParams(parsed.search)) {
+    if (SIGNATURE_PARAMS.has(key)) {
+      signature[key] = value
+      continue
+    }
+    const existing = urlParams[key]
+    if (existing === undefined) urlParams[key] = value
+    else if (Array.isArray(existing)) existing.push(value)
+    else urlParams[key] = [existing, value]
+  }
+
+  let auth: ParsedSmartCdnUrl['auth']
+  const present = Object.keys(signature).length
+  if (present > 0) {
+    if (present !== SIGNATURE_PARAMS.size) {
+      throw notSmartCdnUrl(
+        'incomplete signature parameters; expected auth_key, exp and sig together',
+      )
+    }
+    const expiresAt = Number(signature.exp)
+    if (!Number.isInteger(expiresAt))
+      throw notSmartCdnUrl(`exp '${signature.exp}' is not a timestamp`)
+    auth = { key: signature.auth_key as string, expiresAt, signature: signature.sig as string }
+  }
+
+  return {
+    workspace: decodeOnce(workspaceSlug, 'the workspace'),
+    template: decodeOnce(templateSlug, 'the template'),
+    input: decodeOnce(remainder.slice(slashIndex + 1), 'the input'),
+    urlParams,
+    ...(auth && { auth }),
+    ...(baseUrl != null && { baseUrl }),
+  }
 }

--- a/packages/utils/test/smartCdnGrammar.test.ts
+++ b/packages/utils/test/smartCdnGrammar.test.ts
@@ -1,0 +1,256 @@
+import { createHmac } from 'node:crypto'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSignedSmartCdnUrl,
+  getSmartCdnUrl,
+  parseSmartCdnUrl,
+  stripSmartCdnAuth,
+} from '../src/index.ts'
+import {
+  getSignedSmartCdnUrl as getSignedSmartCdnUrlSync,
+  getSmartCdnUrl as getSmartCdnUrlNode,
+  parseSmartCdnUrl as parseSmartCdnUrlNode,
+  stripSmartCdnAuth as stripSmartCdnAuthNode,
+} from '../src/node.ts'
+
+const signed = {
+  authKey: 'test-key',
+  authSecret: 'test-secret',
+  expiresAt: 1_900_000_000_000,
+  input: 'https://assets.example/image.jpg?version=1',
+  template: 'builtin/serve-image@0.0.1',
+  urlParams: { f: ['avif', 'webp'], fit: true, q: 75, w: 640 },
+  workspace: 'test-workspace',
+}
+
+// The 4.6.0 known answer; the grammar must keep producing and parsing exactly this.
+const knownAnswer =
+  'https://test-workspace.tlcdn.com/builtin%2Fserve-image%400.0.1/' +
+  'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1' +
+  '?auth_key=test-key&exp=1900000000000&f=avif&f=webp&fit=true&q=75&w=640' +
+  '&sig=sha256%3A69e40bc3a447c121a08d059ad9093a39c1beaf5c107a82992d5e78e0d9686f6b'
+
+const storage = {
+  workspace: 'my-workspace',
+  template: 'builtin/storage-serve@0.0.1',
+  input: 'photos/sunset 2.jpg',
+}
+
+const devBaseUrl = 'https://api2-devdock.transloadit.dev/file/{workspace}'
+
+describe('getSmartCdnUrl (unsigned)', () => {
+  it('builds the sorted, encoded URL without any signature parameters', () => {
+    const { authKey: _k, authSecret: _s, expiresAt: _e, ...unsigned } = signed
+    const url = getSmartCdnUrl(unsigned)
+    expect(url).toBe(
+      'https://test-workspace.tlcdn.com/builtin%2Fserve-image%400.0.1/' +
+        'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1' +
+        '?f=avif&f=webp&fit=true&q=75&w=640',
+    )
+    expect(getSmartCdnUrlNode(unsigned)).toBe(url)
+    expect(url).toBe(stripSmartCdnAuth(knownAnswer))
+  })
+
+  it('omits the query string when there are no parameters', () => {
+    expect(getSmartCdnUrl(storage)).toBe(
+      'https://my-workspace.tlcdn.com/builtin%2Fstorage-serve%400.0.1/photos%2Fsunset%202.jpg',
+    )
+  })
+
+  it('substitutes {workspace} in a trusted baseUrl and tolerates a trailing slash', () => {
+    expect(getSmartCdnUrl({ ...storage, baseUrl: `${devBaseUrl}/` })).toBe(
+      'https://api2-devdock.transloadit.dev/file/my-workspace/builtin%2Fstorage-serve%400.0.1/photos%2Fsunset%202.jpg',
+    )
+    expect(getSmartCdnUrl({ ...storage, baseUrl: 'https://cdn.example/x' })).toBe(
+      'https://cdn.example/x/builtin%2Fstorage-serve%400.0.1/photos%2Fsunset%202.jpg',
+    )
+  })
+
+  it('validates its input the same way as the signers', () => {
+    expect(() => getSmartCdnUrl({ ...storage, workspace: '' })).toThrow(
+      new TypeError('workspace is required'),
+    )
+    expect(() => getSmartCdnUrl({ ...storage, baseUrl: 'not a url' })).toThrow(
+      new TypeError("baseUrl must be an absolute URL, got 'not a url'"),
+    )
+    expect(() => getSmartCdnUrl({ ...storage, baseUrl: 'https://cdn.example/?x=1' })).toThrow(
+      'baseUrl must not contain a query string or fragment',
+    )
+  })
+})
+
+describe('getSignedSmartCdnUrl with baseUrl', () => {
+  it('keeps the signature identical because the host is not signed', async () => {
+    const tlcdn = new URL(knownAnswer)
+    const dev = new URL(await getSignedSmartCdnUrl({ ...signed, baseUrl: devBaseUrl }))
+    expect(dev.origin + dev.pathname).toBe(
+      'https://api2-devdock.transloadit.dev/file/test-workspace/builtin%2Fserve-image%400.0.1/' +
+        'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1',
+    )
+    expect(dev.search).toBe(tlcdn.search)
+    expect(getSignedSmartCdnUrlSync({ ...signed, baseUrl: devBaseUrl })).toBe(dev.toString())
+  })
+
+  it('still matches the known answer without a baseUrl', async () => {
+    await expect(getSignedSmartCdnUrl(signed)).resolves.toBe(knownAnswer)
+  })
+})
+
+describe('stripSmartCdnAuth', () => {
+  it('removes auth_key, exp, sig and hsh and leaves every other byte alone', () => {
+    const url =
+      'https://ws.tlcdn.com/t/a%2Fb%20c?auth_key=k&w=100&exp=1&f=avif&f=webp&sig=sha256%3Aabc&hsh=zz&q=a+b'
+    expect(stripSmartCdnAuth(url)).toBe(
+      'https://ws.tlcdn.com/t/a%2Fb%20c?w=100&f=avif&f=webp&q=a+b',
+    )
+    expect(stripSmartCdnAuthNode(url)).toBe(stripSmartCdnAuth(url))
+  })
+
+  it('is idempotent, drops an emptied query, keeps fragments and URLs without a query', () => {
+    const stripped = stripSmartCdnAuth(knownAnswer)
+    expect(stripSmartCdnAuth(stripped)).toBe(stripped)
+    expect(stripSmartCdnAuth('https://ws.tlcdn.com/t/i?auth_key=k&exp=1&sig=s')).toBe(
+      'https://ws.tlcdn.com/t/i',
+    )
+    expect(stripSmartCdnAuth('https://ws.tlcdn.com/t/i?sig=s&w=1#frag')).toBe(
+      'https://ws.tlcdn.com/t/i?w=1#frag',
+    )
+    expect(stripSmartCdnAuth('https://ws.tlcdn.com/t/i')).toBe('https://ws.tlcdn.com/t/i')
+  })
+})
+
+describe('parseSmartCdnUrl', () => {
+  it('inverts the signed known answer', () => {
+    const parsed = parseSmartCdnUrl(knownAnswer)
+    expect(parsed).toEqual({
+      workspace: 'test-workspace',
+      template: 'builtin/serve-image@0.0.1',
+      input: 'https://assets.example/image.jpg?version=1',
+      urlParams: { f: ['avif', 'webp'], fit: 'true', q: '75', w: '640' },
+      auth: {
+        key: 'test-key',
+        expiresAt: 1_900_000_000_000,
+        signature: 'sha256:69e40bc3a447c121a08d059ad9093a39c1beaf5c107a82992d5e78e0d9686f6b',
+      },
+    })
+    expect(parseSmartCdnUrlNode(knownAnswer)).toEqual(parsed)
+  })
+
+  it('round-trips through both builders and both signers', async () => {
+    const unsignedUrl = getSmartCdnUrl({ ...storage, urlParams: { w: 10, f: ['avif', 'webp'] } })
+    const parsedUnsigned = parseSmartCdnUrl(unsignedUrl)
+    expect(parsedUnsigned.auth).toBeUndefined()
+    expect(getSmartCdnUrl(parsedUnsigned)).toBe(unsignedUrl)
+
+    const parsedSigned = parseSmartCdnUrl(knownAnswer)
+    const rebuild = {
+      ...parsedSigned,
+      authKey: parsedSigned.auth?.key ?? '',
+      expiresAt: parsedSigned.auth?.expiresAt,
+      authSecret: signed.authSecret,
+    }
+    await expect(getSignedSmartCdnUrl(rebuild)).resolves.toBe(knownAnswer)
+    expect(getSignedSmartCdnUrlSync(rebuild)).toBe(knownAnswer)
+  })
+
+  it('decodes path segments exactly once', () => {
+    const url = getSmartCdnUrl({ ...storage, input: 'a%2Fb' })
+    expect(url).toContain('/a%252Fb')
+    expect(parseSmartCdnUrl(url).input).toBe('a%2Fb')
+    expect(parseSmartCdnUrl(getSmartCdnUrl(storage)).input).toBe('photos/sunset 2.jpg')
+    // A literal slash in the path joins into the input, like the Console's parser did.
+    expect(parseSmartCdnUrl('https://ws.tlcdn.com/tpl/photos/sunset.jpg').input).toBe(
+      'photos/sunset.jpg',
+    )
+    expect(parseSmartCdnUrl('https://ws.tlcdn.com/tpl/').input).toBe('')
+  })
+
+  it('handles non-ASCII, @ in template names and lower-cases the workspace host', () => {
+    const opts = {
+      workspace: 'My-Workspace',
+      template: 'builtin/serve-image@0.0.1',
+      input: 'ümlaut/€.png',
+    }
+    const parsed = parseSmartCdnUrl(getSmartCdnUrl(opts))
+    expect(parsed).toMatchObject({
+      workspace: 'my-workspace',
+      template: opts.template,
+      input: opts.input,
+    })
+  })
+
+  it('decodes query values by URLSearchParams rules, not twice', () => {
+    const parsed = parseSmartCdnUrl('https://ws.tlcdn.com/t/i?q=a%2Bb&r=x+y&s=%2525')
+    expect(parsed.urlParams).toEqual({ q: 'a+b', r: 'x y', s: '%25' })
+  })
+
+  it('accepts the api2 URL Transform format through a baseUrl with {workspace}', async () => {
+    const url = await getSignedSmartCdnUrl({
+      ...signed,
+      ...storage,
+      urlParams: { cdn: 'required' },
+      baseUrl: devBaseUrl,
+    })
+    expect(url.startsWith('https://api2-devdock.transloadit.dev/file/my-workspace/')).toBe(true)
+    const parsed = parseSmartCdnUrl(url, { baseUrl: devBaseUrl })
+    expect(parsed).toMatchObject({
+      ...storage,
+      urlParams: { cdn: 'required' },
+      auth: { key: 'test-key', expiresAt: signed.expiresAt },
+      baseUrl: 'https://api2-devdock.transloadit.dev/file/my-workspace',
+    })
+    expect(
+      getSignedSmartCdnUrlSync({
+        ...parsed,
+        authKey: 'test-key',
+        authSecret: signed.authSecret,
+        expiresAt: signed.expiresAt,
+      }),
+    ).toBe(url)
+    expect(() => parseSmartCdnUrl(url)).toThrow(/unexpected origin/)
+  })
+
+  it('needs a workspace next to a baseUrl without {workspace}', () => {
+    const url = getSmartCdnUrl({ ...storage, baseUrl: 'https://cdn.example/x' })
+    expect(
+      parseSmartCdnUrl(url, { baseUrl: 'https://cdn.example/x/', workspace: 'my-workspace' }),
+    ).toMatchObject({ ...storage, baseUrl: 'https://cdn.example/x' })
+    expect(() => parseSmartCdnUrl(url, { baseUrl: 'https://cdn.example/x' })).toThrow(
+      /workspace cannot be determined/,
+    )
+  })
+
+  it('rejects anything that is not a Smart CDN URL', () => {
+    expect(() => parseSmartCdnUrl('not a url')).toThrow(/not an absolute URL/)
+    expect(() => parseSmartCdnUrl('https://evil.example/t/i')).toThrow(/unexpected origin/)
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com.evil.example/t/i')).toThrow(
+      /unexpected origin/,
+    )
+    expect(() => parseSmartCdnUrl('http://ws.tlcdn.com/t/i')).toThrow(/unexpected origin/)
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com/tpl')).toThrow(/missing the input segment/)
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com//i')).toThrow(
+      /missing the template segment/,
+    )
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com/t/%E0%A4%A')).toThrow(
+      /malformed percent-encoding/,
+    )
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com/t/i?auth_key=k&sig=s')).toThrow(
+      /incomplete signature parameters/,
+    )
+    expect(() => parseSmartCdnUrl('https://ws.tlcdn.com/t/i?auth_key=k&exp=soon&sig=s')).toThrow(
+      /is not a timestamp/,
+    )
+  })
+
+  it('agrees with an independently computed signature for a parsed URL', () => {
+    const parsed = parseSmartCdnUrl(knownAnswer)
+    const stringToSign =
+      'test-workspace/builtin%2Fserve-image%400.0.1/' +
+      'https%3A%2F%2Fassets.example%2Fimage.jpg%3Fversion%3D1' +
+      '?auth_key=test-key&exp=1900000000000&f=avif&f=webp&fit=true&q=75&w=640'
+    const expected = createHmac('sha256', signed.authSecret).update(stringToSign).digest('hex')
+    expect(parsed.auth?.signature).toBe(`sha256:${expected}`)
+  })
+})


### PR DESCRIPTION
## What

`@transloadit/utils` 4.6.0 ships `getSignedSmartCdnUrl`, but the rest of the Smart CDN URL grammar lived in application code: the Console carries four copies (`parseSmartCdnUrl`, `nonSignedSmartCDNUrl`, `removeAuthParams`, `convertToDevelopmentUrl`) and Uppy's storage plugin had a fifth (origin rewrite). This adds the missing pieces on the same shared `prepareSmartCdnUrl`/`finishSmartCdnUrl` core so they cannot drift:

- `getSmartCdnUrl(options)` — unsigned builder (same options minus credentials/expiry; no `?` when there are no params).
- `parseSmartCdnUrl(url, { baseUrl?, workspace? })` — inverse of the builders: strict `https://{workspace}.tlcdn.com/{template}/{input}` anchoring (or the configured `baseUrl`), percent-decodes path segments exactly once, `URLSearchParams` semantics for the query, repeated params as arrays, `auth_key`/`exp`/`sig` returned as `auth`, clear `TypeError`s for everything else.
- `stripSmartCdnAuth(url)` — removes `auth_key`, `exp`, `sig` (and api2's `hsh`) leaving every other byte untouched; idempotent.
- `baseUrl` option on both builders (root and `./node`), e.g. `https://api2-devdock.transloadit.dev/file/{workspace}` for a local api2. Documented as **trusted configuration**: the signature does not cover the host.

Exported from the root and the `./node` entry; `PreparedSmartCdnUrl.parts` gains the resolved `baseUrl`.

## Why

Converged round-3 refactor item for the Transloadit Storage prototype (transloadit/content#5810, transloadit/uppy#6506): one Smart CDN grammar instead of five, so the Console and Uppy can delete their copies once this ships.

## Verified

- `yarn verify` green (changesets guard, publish check, knip, biome, tsc, transloadit-sync, unit suites).
- New `packages/utils/test/smartCdnGrammar.test.ts`: round trips build → parse → build for unsigned, signed (both signers) and `baseUrl` URLs; repeated params, sorting, encoded slashes/spaces, `@` in template names, non-ASCII, the api2 URL Transform format with `cdn=required`, double-encoded input decoded once, `stripSmartCdnAuth` idempotence; error cases (foreign host, http, missing segments, malformed percent-encoding, incomplete/invalid signature params). The 4.6.0 known-answer vector is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)