### PR TITLE
utils: one storage-grant contract (claims, decode, HS256 mint/verify)

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -135,6 +135,7 @@ export const getSignedSmartCdnUrl = async (opts: SmartCdnUrlOptions): Promise<st
   return finishSmartCdnUrl(prepared, signature)
 }
 
+export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'
 
 export {
   decodeStorageGrant,
@@ -142,4 +143,3 @@ export {
   parseStorageGrantClaims,
   STORAGE_GRANT_SCOPES,
 } from './storageGrant.ts'
-export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -134,3 +134,12 @@ export const getSignedSmartCdnUrl = async (opts: SmartCdnUrlOptions): Promise<st
   const signature = await hmacHex('sha256', opts.authSecret, prepared.stringToSign)
   return finishSmartCdnUrl(prepared, signature)
 }
+
+
+export {
+  decodeStorageGrant,
+  normalizeStorageGrantPrefix,
+  parseStorageGrantClaims,
+  STORAGE_GRANT_SCOPES,
+} from './storageGrant.ts'
+export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -1,17 +1,14 @@
 import type { SignatureAlgorithm } from './index.ts'
 import type { SmartCdnUrlOptions } from './smartCdn.ts'
 import type { SmartCdnImageCandidates, SmartCdnImagePolicyOptions } from './smartCdnImage.ts'
+import type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'
 
 import { Buffer } from 'node:buffer'
 import { createHmac, timingSafeEqual } from 'node:crypto'
 
 import { finishSmartCdnUrl, prepareSmartCdnUrl } from './smartCdn.ts'
-import {
-  parseStorageGrantClaims,
-  type StorageGrantClaims,
-  type StorageGrantScope,
-} from './storageGrant.ts'
 import { createSmartCdnImageCandidates } from './smartCdnImage.ts'
+import { parseStorageGrantClaims } from './storageGrant.ts'
 
 export type { SignatureAlgorithm } from './index.ts'
 export type {
@@ -105,8 +102,9 @@ export function getSignedSmartCdnImageCandidates(
   )
 }
 
-
 // ── storage grants ───────────────────────────────────────────────────────────
+
+export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'
 
 export {
   decodeStorageGrant,
@@ -114,7 +112,6 @@ export {
   parseStorageGrantClaims,
   STORAGE_GRANT_SCOPES,
 } from './storageGrant.ts'
-export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'
 
 const base64url = (value: Buffer | string): string =>
   (typeof value === 'string' ? Buffer.from(value) : value).toString('base64url')

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -2,9 +2,15 @@ import type { SignatureAlgorithm } from './index.ts'
 import type { SmartCdnUrlOptions } from './smartCdn.ts'
 import type { SmartCdnImageCandidates, SmartCdnImagePolicyOptions } from './smartCdnImage.ts'
 
-import { createHmac } from 'node:crypto'
+import { Buffer } from 'node:buffer'
+import { createHmac, timingSafeEqual } from 'node:crypto'
 
 import { finishSmartCdnUrl, prepareSmartCdnUrl } from './smartCdn.ts'
+import {
+  parseStorageGrantClaims,
+  type StorageGrantClaims,
+  type StorageGrantScope,
+} from './storageGrant.ts'
 import { createSmartCdnImageCandidates } from './smartCdnImage.ts'
 
 export type { SignatureAlgorithm } from './index.ts'
@@ -97,4 +103,98 @@ export function getSignedSmartCdnImageCandidates(
       workspace,
     }),
   )
+}
+
+
+// ── storage grants ───────────────────────────────────────────────────────────
+
+export {
+  decodeStorageGrant,
+  normalizeStorageGrantPrefix,
+  parseStorageGrantClaims,
+  STORAGE_GRANT_SCOPES,
+} from './storageGrant.ts'
+export type { StorageGrantClaims, StorageGrantScope } from './storageGrant.ts'
+
+const base64url = (value: Buffer | string): string =>
+  (typeof value === 'string' ? Buffer.from(value) : value).toString('base64url')
+
+export type SignStorageGrantOptions = {
+  /** The workspace slug ("bucket" in S3 terms). */
+  bucket: string
+  /** Key prefix to confine the session to. Default: the whole workspace. */
+  prefix?: string
+  /** Default: read-only. */
+  scopes?: StorageGrantScope[]
+  /** Who the grant is minted for (informational). */
+  sub?: string
+  /** Grant lifetime. Default: 900 (15 minutes). */
+  expiresInSeconds?: number
+  /** Clock override for tests. */
+  nowMs?: number
+}
+
+/**
+ * Mints a storage grant: an HS256 JWT with the v1 claim set, byte-compatible
+ * with api2's `StorageGrantManager` (same header, claim order and encoding).
+ */
+export const signStorageGrant = (
+  options: SignStorageGrantOptions,
+  secret: string,
+): { grant: string; claims: StorageGrantClaims } => {
+  const { bucket, prefix = '', scopes = ['read'], sub, expiresInSeconds = 900 } = options
+  const iat = Math.floor((options.nowMs ?? Date.now()) / 1000)
+  const claims: StorageGrantClaims = {
+    v: 1,
+    bucket,
+    prefix,
+    scopes: [...new Set(scopes)],
+    ...(sub === undefined ? {} : { sub }),
+    iat,
+    exp: iat + expiresInSeconds,
+  }
+  const signingInput = `${base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))}.${base64url(
+    JSON.stringify(claims),
+  )}`
+  const signature = base64url(createHmac('sha256', secret).update(signingInput).digest())
+  return { grant: `${signingInput}.${signature}`, claims }
+}
+
+/**
+ * Verifies a storage grant: HS256 signature (timing-safe), strict v1 claim
+ * shape, and expiry. Throws with a stable message on any failure.
+ */
+export const verifyStorageGrant = (
+  token: string,
+  secret: string,
+  { nowMs = Date.now() }: { nowMs?: number } = {},
+): StorageGrantClaims => {
+  const [headerPart, payloadPart, signaturePart, ...rest] = token.split('.')
+  if (!headerPart || !payloadPart || !signaturePart || rest.length > 0) {
+    throw new Error('Invalid storage grant')
+  }
+  const expected = createHmac('sha256', secret).update(`${headerPart}.${payloadPart}`).digest()
+  const actual = Buffer.from(signaturePart, 'base64url')
+  if (actual.length !== expected.length || !timingSafeEqual(actual, expected)) {
+    throw new Error('Invalid storage grant signature')
+  }
+  let header: unknown
+  let payload: unknown
+  try {
+    header = JSON.parse(Buffer.from(headerPart, 'base64url').toString('utf8'))
+    payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf8'))
+  } catch {
+    throw new Error('Invalid storage grant')
+  }
+  if (
+    typeof header !== 'object' ||
+    header === null ||
+    (header as { alg?: unknown }).alg !== 'HS256'
+  ) {
+    throw new Error('Invalid storage grant algorithm')
+  }
+  const claims = parseStorageGrantClaims(payload)
+  if (claims === null) throw new Error('Invalid storage grant claims')
+  if (claims.exp <= Math.floor(nowMs / 1000)) throw new Error('The storage grant has expired')
+  return claims
 }

--- a/packages/utils/src/storageGrant.ts
+++ b/packages/utils/src/storageGrant.ts
@@ -1,0 +1,90 @@
+/**
+ * The Transloadit Storage grant: a short-lived HS256 JWT an integrator's
+ * server mints (or api2's `POST /storage/grants` mints for it) and
+ * Companion's S3 provider verifies. This module is the one wire contract —
+ * claim shape, decoding, and (in `@transloadit/utils/node`) minting and
+ * verification — so the implementations cannot drift apart.
+ *
+ * Everything in this file is browser-safe: the client may *read* a grant's
+ * claims to decide what UI to show, but verification is the server's job.
+ */
+
+export const STORAGE_GRANT_SCOPES = ['read', 'write'] as const
+export type StorageGrantScope = (typeof STORAGE_GRANT_SCOPES)[number]
+
+export type StorageGrantClaims = {
+  v: 1
+  /** The workspace slug ("bucket" in S3 terms). */
+  bucket: string
+  /** Key prefix the session is confined to; may be empty. */
+  prefix: string
+  scopes: StorageGrantScope[]
+  /** Who the grant was minted for (informational). */
+  sub?: string
+  /** Unix seconds. */
+  iat?: number
+  /** Unix seconds. */
+  exp: number
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+/**
+ * Validates a decoded JWT payload against the grant contract. Returns the
+ * claims (scopes deduplicated) or null when the shape is not a v1 grant.
+ */
+export const parseStorageGrantClaims = (payload: unknown): StorageGrantClaims | null => {
+  if (
+    !isRecord(payload) ||
+    payload.v !== 1 ||
+    typeof payload.bucket !== 'string' ||
+    payload.bucket.length === 0 ||
+    typeof payload.prefix !== 'string' ||
+    !Array.isArray(payload.scopes) ||
+    !payload.scopes.every(
+      (scope): scope is StorageGrantScope =>
+        typeof scope === 'string' && (STORAGE_GRANT_SCOPES as readonly string[]).includes(scope),
+    ) ||
+    typeof payload.exp !== 'number'
+  ) {
+    return null
+  }
+  return {
+    v: 1,
+    bucket: payload.bucket,
+    prefix: payload.prefix,
+    scopes: [...new Set(payload.scopes)],
+    ...(typeof payload.sub === 'string' && { sub: payload.sub }),
+    ...(typeof payload.iat === 'number' && { iat: payload.iat }),
+    exp: payload.exp,
+  }
+}
+
+/** Companion's prefix policy: no leading slashes, a trailing slash unless empty. */
+export const normalizeStorageGrantPrefix = (prefix: string): string => {
+  const cleaned = prefix.replace(/^\/+/, '')
+  return cleaned.length === 0 || cleaned.endsWith('/') ? cleaned : `${cleaned}/`
+}
+
+const decodeBase64UrlToUtf8 = (input: string): string => {
+  const base64 = input.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  const binary = atob(padded)
+  return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)))
+}
+
+/**
+ * Reads a grant's payload without verifying the signature — for clients that
+ * only need to know what the session will be allowed to do. Returns null for
+ * anything that does not decode to a v1 grant.
+ */
+export const decodeStorageGrant = (token: string): StorageGrantClaims | null => {
+  try {
+    const payload = token.split('.')[1]
+    if (payload === undefined || payload.length === 0) return null
+    return parseStorageGrantClaims(JSON.parse(decodeBase64UrlToUtf8(payload)))
+  } catch {
+    return null
+  }
+}

--- a/packages/utils/test/storageGrant.test.ts
+++ b/packages/utils/test/storageGrant.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  decodeStorageGrant,
+  normalizeStorageGrantPrefix,
+  parseStorageGrantClaims,
+} from '../src/storageGrant.ts'
+import { signStorageGrant, verifyStorageGrant } from '../src/node.ts'
+
+const SECRET = 'test-secret-0123456789abcdef0123456789abcdef'
+
+describe('storage grants', () => {
+  test('mints the exact api2 StorageGrantManager token for fixed inputs', () => {
+    // Golden vector: header {"alg":"HS256","typ":"JWT"}, claim order
+    // v/bucket/prefix/scopes/sub/iat/exp, base64url without padding.
+    const { grant, claims } = signStorageGrant(
+      {
+        bucket: 'toystory',
+        prefix: 'photos/',
+        scopes: ['read', 'write'],
+        sub: 'user-1',
+        expiresInSeconds: 900,
+        nowMs: 1_750_000_000_000,
+      },
+      SECRET,
+    )
+    expect(claims).toEqual({
+      v: 1,
+      bucket: 'toystory',
+      prefix: 'photos/',
+      scopes: ['read', 'write'],
+      sub: 'user-1',
+      iat: 1_750_000_000,
+      exp: 1_750_000_900,
+    })
+    const [headerPart, payloadPart] = grant.split('.')
+    expect(Buffer.from(headerPart!, 'base64url').toString('utf8')).toBe(
+      '{"alg":"HS256","typ":"JWT"}',
+    )
+    expect(Buffer.from(payloadPart!, 'base64url').toString('utf8')).toBe(
+      '{"v":1,"bucket":"toystory","prefix":"photos/","scopes":["read","write"],"sub":"user-1","iat":1750000000,"exp":1750000900}',
+    )
+    expect(grant).not.toContain('=')
+  })
+
+  test('mint → verify roundtrip, unicode prefix included', () => {
+    const { grant } = signStorageGrant(
+      { bucket: 'b', prefix: 'café/ぱんだ/', nowMs: 1_750_000_000_000 },
+      SECRET,
+    )
+    const claims = verifyStorageGrant(grant, SECRET, { nowMs: 1_750_000_100_000 })
+    expect(claims.prefix).toBe('café/ぱんだ/')
+    expect(claims.scopes).toEqual(['read'])
+    expect(decodeStorageGrant(grant)?.prefix).toBe('café/ぱんだ/')
+  })
+
+  test('rejects tampering, wrong secrets, expiry, and malformed tokens', () => {
+    const { grant } = signStorageGrant({ bucket: 'b', nowMs: 1_750_000_000_000 }, SECRET)
+    expect(() => verifyStorageGrant(grant, 'other-secret')).toThrow(/signature/)
+    const [h, p, s] = grant.split('.')
+    const forged = `${h}.${Buffer.from('{"v":1,"bucket":"evil","prefix":"","scopes":["write"],"exp":9999999999}').toString('base64url')}.${s}`
+    expect(() => verifyStorageGrant(forged, SECRET)).toThrow(/signature/)
+    expect(() =>
+      verifyStorageGrant(grant, SECRET, { nowMs: 1_750_000_901_000 }),
+    ).toThrow(/expired/)
+    expect(() => verifyStorageGrant('not-a-jwt', SECRET)).toThrow(/Invalid/)
+    expect(() => verifyStorageGrant(`${grant}.extra`, SECRET)).toThrow(/Invalid/)
+  })
+
+  test('claim parsing is strict, dedupes scopes, and decode is lenient about padding', () => {
+    expect(parseStorageGrantClaims(null)).toBeNull()
+    expect(parseStorageGrantClaims({ v: 2, bucket: 'b', prefix: '', scopes: [], exp: 1 })).toBeNull()
+    expect(parseStorageGrantClaims({ v: 1, bucket: '', prefix: '', scopes: [], exp: 1 })).toBeNull()
+    expect(
+      parseStorageGrantClaims({ v: 1, bucket: 'b', prefix: '', scopes: ['read', 'admin'], exp: 1 }),
+    ).toBeNull()
+    expect(
+      parseStorageGrantClaims({
+        v: 1,
+        bucket: 'b',
+        prefix: '',
+        scopes: ['read', 'read', 'write'],
+        exp: 1,
+      })?.scopes,
+    ).toEqual(['read', 'write'])
+    expect(decodeStorageGrant('only-one-part')).toBeNull()
+    expect(decodeStorageGrant('a..c')).toBeNull()
+  })
+
+  test('normalizeStorageGrantPrefix mirrors Companion', () => {
+    expect(normalizeStorageGrantPrefix('')).toBe('')
+    expect(normalizeStorageGrantPrefix('/photos')).toBe('photos/')
+    expect(normalizeStorageGrantPrefix('photos/')).toBe('photos/')
+    expect(normalizeStorageGrantPrefix('//a/b')).toBe('a/b/')
+  })
+})

--- a/packages/utils/test/storageGrant.test.ts
+++ b/packages/utils/test/storageGrant.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
+import { signStorageGrant, verifyStorageGrant } from '../src/node.ts'
 import {
   decodeStorageGrant,
   normalizeStorageGrantPrefix,
   parseStorageGrantClaims,
 } from '../src/storageGrant.ts'
-import { signStorageGrant, verifyStorageGrant } from '../src/node.ts'
 
 const SECRET = 'test-secret-0123456789abcdef0123456789abcdef'
 
@@ -34,10 +34,10 @@ describe('storage grants', () => {
       exp: 1_750_000_900,
     })
     const [headerPart, payloadPart] = grant.split('.')
-    expect(Buffer.from(headerPart!, 'base64url').toString('utf8')).toBe(
+    expect(Buffer.from(headerPart ?? '', 'base64url').toString('utf8')).toBe(
       '{"alg":"HS256","typ":"JWT"}',
     )
-    expect(Buffer.from(payloadPart!, 'base64url').toString('utf8')).toBe(
+    expect(Buffer.from(payloadPart ?? '', 'base64url').toString('utf8')).toBe(
       '{"v":1,"bucket":"toystory","prefix":"photos/","scopes":["read","write"],"sub":"user-1","iat":1750000000,"exp":1750000900}',
     )
     expect(grant).not.toContain('=')
@@ -60,16 +60,16 @@ describe('storage grants', () => {
     const [h, p, s] = grant.split('.')
     const forged = `${h}.${Buffer.from('{"v":1,"bucket":"evil","prefix":"","scopes":["write"],"exp":9999999999}').toString('base64url')}.${s}`
     expect(() => verifyStorageGrant(forged, SECRET)).toThrow(/signature/)
-    expect(() =>
-      verifyStorageGrant(grant, SECRET, { nowMs: 1_750_000_901_000 }),
-    ).toThrow(/expired/)
+    expect(() => verifyStorageGrant(grant, SECRET, { nowMs: 1_750_000_901_000 })).toThrow(/expired/)
     expect(() => verifyStorageGrant('not-a-jwt', SECRET)).toThrow(/Invalid/)
     expect(() => verifyStorageGrant(`${grant}.extra`, SECRET)).toThrow(/Invalid/)
   })
 
   test('claim parsing is strict, dedupes scopes, and decode is lenient about padding', () => {
     expect(parseStorageGrantClaims(null)).toBeNull()
-    expect(parseStorageGrantClaims({ v: 2, bucket: 'b', prefix: '', scopes: [], exp: 1 })).toBeNull()
+    expect(
+      parseStorageGrantClaims({ v: 2, bucket: 'b', prefix: '', scopes: [], exp: 1 }),
+    ).toBeNull()
     expect(parseStorageGrantClaims({ v: 1, bucket: '', prefix: '', scopes: [], exp: 1 })).toBeNull()
     expect(
       parseStorageGrantClaims({ v: 1, bucket: 'b', prefix: '', scopes: ['read', 'admin'], exp: 1 }),


### PR DESCRIPTION
One source of truth for the Transloadit Storage grant JWT that today exists as four hand-rolled copies (api2 `StorageGrantManager`, Companion's `parseGrantClaims`, @uppy/s3's `decodeGrant`, and the Console's grant route).

- Root (browser-safe): `StorageGrantClaims`/`StorageGrantScope` types, `parseStorageGrantClaims` (strict shape validation, scope dedupe), `decodeStorageGrant` (unverified JWT payload decode, UTF-8 safe), `normalizeStorageGrantPrefix` (Companion's leading-slash strip + trailing-slash).
- `/node`: `signStorageGrant` (deterministic HS256, byte-compatible with api2's `StorageGrantManager`) and `verifyStorageGrant` (timing-safe signature check, HS256-only header, strict claims, expiry).
- Vectors: fixed-input golden token, mint→verify roundtrip, tamper/expiry/shape rejections, unicode prefixes, base64url padding, scope dedupe.

Once published, api2 #8844, uppy #6506 (Companion + @uppy/s3) and content #5810 consume this instead of their local copies (≈ −40…−70 lines across the repos, and the contract cannot drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)