### PR TITLE
Add the missed changeset for the storage-grant codec (#483)

### DIFF
--- a/.changeset/storage-grant-codec.md
+++ b/.changeset/storage-grant-codec.md
@@ -1,0 +1,5 @@
+---
+'@transloadit/utils': minor
+---
+
+Add the storage-grant contract/codec: `StorageGrantClaims` types, `parseStorageGrantClaims`, browser-safe `decodeStorageGrant`, `normalizeStorageGrantPrefix` at the root, and deterministic HS256 `signStorageGrant`/`verifyStorageGrant` under `@transloadit/utils/node` — one wire contract for the grants minted by api2/integrator servers and verified by Companion's S3 provider.


### PR DESCRIPTION
PR #483 merged without its changeset, so the Release run had nothing to version. This is that changeset: minor for @transloadit/utils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)